### PR TITLE
DEV-388:ADD: Stringify objects to JSON if Cassandra column to be inserted is text, varchar or ascii

### DIFF
--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -109,7 +109,12 @@ class JSONSchema {
      */
     static cassandraStringTypeOrDefault(type, val) {
         const stringTypes = [ 'text', 'varchar', 'ascii' ];
-        return stringTypes.includes(type) ? val.toString() : val;
+
+        if (stringTypes.includes(type)) {
+            return Utils.isObject(val) ? JSON.stringify(val) : val.toString();
+        }
+
+        return val;
     }
 
     /**

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -107,10 +107,10 @@ class JSONSchema {
      * @param {any} val
      * @returns {string | any}
      */
-    static cassandraStringTypeOrDefault(type, val) {
+    static cassandraStringTypeOrDefault(type, val = null) {
         const stringTypes = [ 'text', 'varchar', 'ascii' ];
 
-        if (stringTypes.includes(type)) {
+        if (stringTypes.includes(type) && val !== null) {
             return Utils.isObject(val) ? JSON.stringify(val) : val.toString();
         }
 

--- a/plugin/cassandra-tables.json
+++ b/plugin/cassandra-tables.json
@@ -5,7 +5,7 @@
       "deviceId": "text",
       "timestamp": "timestamp",
       "id": "int",
-      "parameters": "frozen<params>",
+      "parameters": "text",
 
       "__primaryKey__": [ "command", "deviceId" ],
       "__clusteredKey__": [ "timestamp" ],

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -85,4 +85,11 @@ describe('JSON Schema', () => {
         assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('ascii', 123), '123');
         assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('varchar', 123), '123');
     });
+
+    it('Should stringify to JSON object if Cassandra type is text, ascii or varchar', () => {
+        const obj = { prop: 'test' };
+        const stringified = JSON.stringify(obj);
+
+        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', obj), stringified);
+    });
 });

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -92,4 +92,9 @@ describe('JSON Schema', () => {
 
         assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', obj), stringified);
     });
+
+    it('Should return null if second argument (value) for cassandraStringTypeOrDefault is null or undefined', () => {
+        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text'), null);
+        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', null), null);
+    });
 });


### PR DESCRIPTION
- Parameters are text by default (this means stringified arbitrary object)