### PR TITLE
DEV-388:ADD: Handling of schema mismatch, existent structure or column/field type mismatch

### DIFF
--- a/cassandra/lib/BaseSchemaBuilder.js
+++ b/cassandra/lib/BaseSchemaBuilder.js
@@ -2,13 +2,18 @@ const Utils = require('./Utils');
 
 class BaseSchemaBuilder {
     static get CREATE_QUERY_TYPE() { return 0; }
+    static get DROP_QUERY_TYPE() { return 1; }
+
+    static get TYPE_STRUCTURE() { return 'TYPE'; }
+    static get TABLE_STRUCTURE() { return 'TABLE'; }
 
     constructor() {
-        this._query = '';
+        this._queryString = '';
         this._queryType = null;
         this._name = '';
         this._definition = '';
-        this._ifNotExists = '';
+        this._ifCondition = '';
+        this._structureType = '';
     }
 
     /**
@@ -25,7 +30,7 @@ class BaseSchemaBuilder {
      * @returns {string}
      */
     build() {
-        return `${this._query} ${this._ifNotExists}${this._name}${this._definition}`;
+        return `${this._queryString} ${this._ifCondition}${this._name}${this._definition}`;
     }
 
     /**
@@ -43,24 +48,62 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifNotExists() {
-        if(this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
-            // @TODO Remove this variable, use append to this._query and appropriate flag for IF NOT EXISTS
-            this._ifNotExists = 'IF NOT EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
+            // @TODO Remove this variable, use append to this._queryString and appropriate flag for IF NOT EXISTS
+            this._ifCondition = 'IF NOT EXISTS ';
         }
 
         return this;
     }
 
     /**
-     * Specifies type of query
-     * @param {string} structureType
-     * @param [name = '']
+     * Drop structure only if it exists
      * @returns {BaseSchemaBuilder}
      */
-    _create(structureType, name = '') {
-        this._queryType = BaseSchemaBuilder.CREATE_QUERY_TYPE;        
-        this._query = `CREATE ${structureType}`;
-        
+    ifExists() {
+        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE) {
+            this._ifCondition = 'IF EXISTS ';
+        }
+
+        return this;
+    }
+
+    /**
+     * Specifies create type of query
+     * @param [name = '']
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _create(name = '') {
+        return this._query(BaseSchemaBuilder.CREATE_QUERY_TYPE, name);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [name = '']
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _drop(name = '') {
+        return this._query(BaseSchemaBuilder.DROP_QUERY_TYPE, name);
+    }
+
+    /**
+     * Specify query with given type
+     * @param type
+     * @param name
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _query(type, name = '') {
+        const queryTypes = {
+            [BaseSchemaBuilder.CREATE_QUERY_TYPE]: 'CREATE',
+            [BaseSchemaBuilder.DROP_QUERY_TYPE]: 'DROP'
+        };
+
+        this._queryType = type;
+        this._queryString = `${queryTypes[type]} ${this._structureType}`;
+
         return Utils.isEmpty(name) ? this : this.withName(name);
     }
 }

--- a/cassandra/lib/BaseSchemaBuilder.js
+++ b/cassandra/lib/BaseSchemaBuilder.js
@@ -1,18 +1,12 @@
 const Utils = require('./Utils');
 
 class BaseSchemaBuilder {
-    static get CREATE_QUERY_TYPE() { return 0; }
-    static get DROP_QUERY_TYPE() { return 1; }
-
-    static get TYPE_STRUCTURE() { return 'TYPE'; }
-    static get TABLE_STRUCTURE() { return 'TABLE'; }
-
     constructor() {
         this._queryString = '';
         this._queryType = null;
         this._name = '';
         this._definition = '';
-        this._ifCondition = '';
+        this._ifConditionExists = false;
         this._structureType = '';
     }
 
@@ -30,7 +24,7 @@ class BaseSchemaBuilder {
      * @returns {string}
      */
     build() {
-        return `${this._queryString} ${this._ifCondition}${this._name}${this._definition}`;
+        return `${this._queryString} ${this._name}${this._definition}`;
     }
 
     /**
@@ -48,9 +42,9 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifNotExists() {
-        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
-            // @TODO Remove this variable, use append to this._queryString and appropriate flag for IF NOT EXISTS
-            this._ifCondition = 'IF NOT EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE && !this._ifConditionExists) {
+            this._ifConditionExists = true;
+            this._queryString += ' IF NOT EXISTS';
         }
 
         return this;
@@ -61,8 +55,9 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifExists() {
-        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE) {
-            this._ifCondition = 'IF EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE && !this._ifConditionExists) {
+            this._ifConditionExists = true;
+            this._queryString += ' IF EXISTS';
         }
 
         return this;
@@ -106,6 +101,12 @@ class BaseSchemaBuilder {
 
         return Utils.isEmpty(name) ? this : this.withName(name);
     }
+
+    static get CREATE_QUERY_TYPE() { return 0; }
+    static get DROP_QUERY_TYPE() { return 1; }
+
+    static get TYPE_STRUCTURE() { return 'TYPE'; }
+    static get TABLE_STRUCTURE() { return 'TABLE'; }
 }
 
 module.exports = BaseSchemaBuilder;

--- a/cassandra/lib/CQLBuilder.js
+++ b/cassandra/lib/CQLBuilder.js
@@ -27,6 +27,23 @@ class CQLBuilder {
     }
 
     /**
+     * Creates query based on given type
+     * @param type CQLBuilder.INSERT_QUERY or CQLBuilder.UPDATE_QUERY
+     * @returns {QueryBuilder}
+     */
+    static query(type) {
+        const queryBuilder = new QueryBuilder();
+
+        if (type === CQLBuilder.INSERT_QUERY) {
+            queryBuilder.insertInto();
+        } else if (type === CQLBuilder.UPDATE_QUERY) {
+            queryBuilder.update();
+        }
+
+        return queryBuilder;
+    }
+
+    /**
      * Creates table creation type of query
      * @param tableName
      * @returns {TableSchemaBuilder}
@@ -44,16 +61,12 @@ class CQLBuilder {
         return new UDTSchemaBuilder().createType(typeName);
     }
 
-    static query(type) {
-        const queryBuilder = new QueryBuilder();
+    static dropTable(tableName = '') {
+        return new TableSchemaBuilder().dropTable(tableName);
+    }
 
-        if (type === CQLBuilder.INSERT_QUERY) {
-            queryBuilder.insertInto();
-        } else if (type === CQLBuilder.UPDATE_QUERY) {
-            queryBuilder.update();
-        }
-
-        return queryBuilder;
+    static dropType(typeName = '') {
+        return new UDTSchemaBuilder().dropType(typeName);
     }
 }
 

--- a/cassandra/lib/CassandraUtils.js
+++ b/cassandra/lib/CassandraUtils.js
@@ -1,3 +1,5 @@
+const Utils = require('./Utils');
+
 class CassandraUtils {
     /**
      * Extracts pure type name from column type definition
@@ -7,6 +9,26 @@ class CassandraUtils {
     static extractTypeName(str) {
         /* @TODO Extraction of UDT name from nested structures e.g. frozen<list<tuple<UDT_NAME, int>>> */
         return str ? str.replace(/frozen<|>/ig, '') : '';
+    }
+
+    /**
+     * Cast to string if Cassandra column is text, varchar or ascii type
+     * @param {string} type
+     * @param {any} val
+     * @returns {string | any}
+     */
+    static cassandraStringTypeOrDefault(type, val = null) {
+        const stringTypes = [ 'text', 'varchar', 'ascii' ];
+
+        if (stringTypes.includes(type) && val !== null) {
+            return Utils.isObject(val) ? JSON.stringify(val) : val.toString();
+        }
+
+        return val;
+    }
+
+    static replaceTypeAliases(str) {
+        return str.replace(/varchar/g, 'text');
     }
 }
 

--- a/cassandra/lib/CassandraUtils.js
+++ b/cassandra/lib/CassandraUtils.js
@@ -8,6 +8,43 @@ class CassandraUtils {
         /* @TODO Extraction of UDT name from nested structures e.g. frozen<list<tuple<UDT_NAME, int>>> */
         return str ? str.replace(/frozen<|>/ig, '') : '';
     }
+
+    /**
+     * Returns data type name by given numeric code
+     * @param {Number} code
+     * @returns {string|undefined}
+     */
+    static getDataTypeNameByCode(code) {
+        return CassandraUtils._dataTypesByCode[code];
+    }
 }
+
+CassandraUtils._dataTypesByCode = {
+    1: 'ascii',
+    2: 'bigint',
+    3: 'blob',
+    4: 'boolean',
+    5: 'counter',
+    6: 'decimal',
+    7: 'double',
+    8: 'float',
+    9: 'int',
+    10: 'text',
+    11: 'timestamp',
+    12: 'uuid',
+    13: 'varchar',
+    14: 'varint',
+    15: 'timeuuid',
+    16: 'inet',
+    17: 'date',
+    18: 'time',
+    19: 'smallint',
+    20: 'tinyint',
+    32: 'list',
+    33: 'map',
+    34: 'set',
+    48: 'udt',
+    49: 'tuple'
+};
 
 module.exports = CassandraUtils;

--- a/cassandra/lib/CassandraUtils.js
+++ b/cassandra/lib/CassandraUtils.js
@@ -10,6 +10,27 @@ class CassandraUtils {
     }
 
     /**
+     * Returns full name of type with its types if type is complex
+     * @param {object} typeDescriptor cassandra-driver metadata type object
+     * @returns {string}
+     */
+    static fullTypeName(typeDescriptor) {
+        const descr = typeDescriptor;
+        let name = CassandraUtils.getDataTypeNameByCode(descr.code);
+
+        if (descr.info) {
+            const nestedTypes = [];
+            descr.info.forEach(type => {
+                nestedTypes.push(CassandraUtils.getDataTypeNameByCode(type.code));
+            });
+
+            name += `<${nestedTypes.join(',')}>`;
+        }
+
+        return name;
+    }
+
+    /**
      * Returns data type name by given numeric code
      * @param {Number} code
      * @returns {string|undefined}

--- a/cassandra/lib/CassandraUtils.js
+++ b/cassandra/lib/CassandraUtils.js
@@ -8,64 +8,6 @@ class CassandraUtils {
         /* @TODO Extraction of UDT name from nested structures e.g. frozen<list<tuple<UDT_NAME, int>>> */
         return str ? str.replace(/frozen<|>/ig, '') : '';
     }
-
-    /**
-     * Returns full name of type with its types if type is complex
-     * @param {object} typeDescriptor cassandra-driver metadata type object
-     * @returns {string}
-     */
-    static fullTypeName(typeDescriptor) {
-        const descr = typeDescriptor;
-        let name = CassandraUtils.getDataTypeNameByCode(descr.code);
-
-        if (descr.info) {
-            const nestedTypes = [];
-            descr.info.forEach(type => {
-                nestedTypes.push(CassandraUtils.getDataTypeNameByCode(type.code));
-            });
-
-            name += `<${nestedTypes.join(',')}>`;
-        }
-
-        return name;
-    }
-
-    /**
-     * Returns data type name by given numeric code
-     * @param {Number} code
-     * @returns {string|undefined}
-     */
-    static getDataTypeNameByCode(code) {
-        return CassandraUtils._dataTypesByCode[code];
-    }
 }
-
-CassandraUtils._dataTypesByCode = {
-    1: 'ascii',
-    2: 'bigint',
-    3: 'blob',
-    4: 'boolean',
-    5: 'counter',
-    6: 'decimal',
-    7: 'double',
-    8: 'float',
-    9: 'int',
-    10: 'text',
-    11: 'timestamp',
-    12: 'uuid',
-    13: 'varchar',
-    14: 'varint',
-    15: 'timeuuid',
-    16: 'inet',
-    17: 'date',
-    18: 'time',
-    19: 'smallint',
-    20: 'tinyint',
-    32: 'list',
-    33: 'map',
-    34: 'set',
-    48: 'udt',
-    49: 'tuple'
-};
 
 module.exports = CassandraUtils;

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -213,29 +213,29 @@ class JSONSchema {
      * @param metadataDescriptor cassandra-driver metadata object
      * @returns {boolean}
      */
-    compareColumnsSetWithMetadata(metadataDescriptor) {
+    comparePropertySetWithMetadata(metadataDescriptor) {
         return Metadata.create(metadataDescriptor).isSameMembersSchema(this);
     }
 
     /**
-     * Returns array of column types mismatches in schema with metadata
+     * Returns array of property types mismatches in schema with metadata
      * @param metadataDescriptor cassandra-driver metadata object
      * @returns {Array}
      */
-    diffColumnTypesWithMetadata(metadataDescriptor) {
+    diffPropertyTypesWithMetadata(metadataDescriptor) {
         const mismatches = [];
         const metadata = Metadata.create(metadataDescriptor);
 
-        const columns = this.getColumns();
+        const props = this.getProperties();
 
-        for (let colName in columns) {
-            if (metadata.columnExists(colName)) {
-                const realType = metadata.getColumnFullTypeName(colName);
-                const schemaType = CassandraUtils.replaceTypeAliases(columns[colName].replace(/\s/g, ''));
+        for (let propName in props) {
+            if (metadata.columnExists(propName)) {
+                const realType = metadata.getFullTypeName(propName);
+                const schemaType = CassandraUtils.replaceTypeAliases(props[propName].replace(/\s/g, ''));
 
                 if (realType !== schemaType) {
                     mismatches.push({
-                        colName,
+                        propName,
                         realType,
                         schemaType
                     });
@@ -250,7 +250,7 @@ class JSONSchema {
      * Returns schema properties and values which are not reserved
      * @returns {Object}
      */
-    getColumns() {
+    getProperties() {
         const cols = {};
 
         for (let prop in this._schema) {

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -263,6 +263,10 @@ class JSONSchema {
         return cols;
     }
 
+    /**
+     * Returns true if schema contains __dropIfExists__ set in true
+     * @returns {boolean}
+     */
     shouldBeDropped() {
         const dropIfExists = this._schema[JSONSchema.DROP_IF_EXISTS];
         return !!Utils.booleanOrDefault(dropIfExists);

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -252,8 +252,8 @@ class JSONSchema {
         for (let colName in columns) {
             if (colName in metadata.columnsByName) {
                 const { type: dataType } = metadata.columnsByName[colName];
-                const realType = CassandraUtils.getDataTypeNameByCode(dataType.code);
-                const schemaType = columns[colName];
+                const realType = CassandraUtils.fullTypeName(dataType);
+                const schemaType = columns[colName].replace(/\s/g, '');
 
                 if (realType !== schemaType) {
                     mismatches.push({

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -138,7 +138,7 @@ class JSONSchema {
                     const udtSchema = new JSONSchema(this._schema[prop]);
                     filteredObj[prop] = udtSchema.filterData(obj[prop]);
                 } else {
-                    filteredObj[prop] = JSONSchema.cassandraStringTypeOrDefault(this._schema[prop], obj[prop]);
+                    filteredObj[prop] = CassandraUtils.cassandraStringTypeOrDefault(this._schema[prop], obj[prop]);
                 }
             }
         }
@@ -187,22 +187,6 @@ class JSONSchema {
     }
 
     /**
-     * Cast to string if Cassandra column is text, varchar or ascii type
-     * @param {string} type
-     * @param {any} val
-     * @returns {string | any}
-     */
-    static cassandraStringTypeOrDefault(type, val = null) {
-        const stringTypes = [ 'text', 'varchar', 'ascii' ];
-
-        if (stringTypes.includes(type) && val !== null) {
-            return Utils.isObject(val) ? JSON.stringify(val) : val.toString();
-        }
-
-        return val;
-    }
-
-    /**
      * Replaces current user type references in column definitions with real objects of user type definitions
      * @param {object} types
      * @returns {JSONSchema}
@@ -247,7 +231,7 @@ class JSONSchema {
         for (let colName in columns) {
             if (metadata.columnExists(colName)) {
                 const realType = metadata.getColumnFullTypeName(colName);
-                const schemaType = columns[colName].replace(/\s/g, '');
+                const schemaType = CassandraUtils.replaceTypeAliases(columns[colName].replace(/\s/g, ''));
 
                 if (realType !== schemaType) {
                     mismatches.push({

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -1,6 +1,6 @@
 const Utils = require('./Utils');
 const CassandraUtils = require('./CassandraUtils');
-const Metadata = require('./Metadata');
+const Metadata = require('./metadata');
 
 class JSONSchema {
     static get PRIMARY_KEY() { return '__primaryKey__'; }
@@ -230,7 +230,7 @@ class JSONSchema {
      * @returns {boolean}
      */
     compareColumnsSetWithMetadata(metadataDescriptor) {
-        return new Metadata(metadataDescriptor).isSameColumnsSchema(this);
+        return Metadata.create(metadataDescriptor).isSameMembersSchema(this);
     }
 
     /**
@@ -240,7 +240,7 @@ class JSONSchema {
      */
     diffColumnTypesWithMetadata(metadataDescriptor) {
         const mismatches = [];
-        const metadata = new Metadata(metadataDescriptor);
+        const metadata = Metadata.create(metadataDescriptor);
 
         const columns = this.getColumns();
 
@@ -263,7 +263,7 @@ class JSONSchema {
     }
 
     /**
-     * Returns schema properties ad values which are not reserved
+     * Returns schema properties and values which are not reserved
      * @returns {Object}
      */
     getColumns() {

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -7,6 +7,7 @@ class JSONSchema {
     static get CLUSTERED_KEY() { return '__clusteredKey__'; }
     static get ORDER() { return '__order__'; }
     static get OPTIONS() { return '__options__'; }
+    static get DROP_IF_EXISTS() { return '__dropIfExists__'; }
 
     constructor(schema = {}) {
         this._schema = Utils.copy(schema);
@@ -262,6 +263,11 @@ class JSONSchema {
         return cols;
     }
 
+    shouldBeDropped() {
+        const dropIfExists = this._schema[JSONSchema.DROP_IF_EXISTS];
+        return !!Utils.booleanOrDefault(dropIfExists);
+    }
+
     /**
      * Returns true if property name is not specified as reserved
      * @param propName
@@ -272,7 +278,8 @@ class JSONSchema {
             JSONSchema.PRIMARY_KEY,
             JSONSchema.CLUSTERED_KEY,
             JSONSchema.ORDER,
-            JSONSchema.OPTIONS
+            JSONSchema.OPTIONS,
+            JSONSchema.DROP_IF_EXISTS
         ];
 
         return !reservedProps.includes(propName);

--- a/cassandra/lib/Metadata.js
+++ b/cassandra/lib/Metadata.js
@@ -34,21 +34,52 @@ class Metadata {
      * @returns {string}
      */
     getColumnFullTypeName(colName) {
-        const type = this._md.columnsByName[colName].type;
-        let name = Metadata.getDataTypeNameByCode(type.code);
+        const type = this._getTypeDescription(colName);
+        let name = this._complexType(colName) || this._customType(colName) || this._simpleType(colName);
+
+        if (type.options && type.options.frozen) {
+            name = `frozen<${name}>`;
+        }
+
+        return name;
+    }
+
+    _complexType(colName) {
+        const type = this._getTypeDescription(colName);
 
         if (type.info && type.info.length) {
+            const name = Metadata.getDataTypeNameByCode(type.code);
+
             const nestedTypes = [];
             type.info.forEach(t => {
                 nestedTypes.push(Metadata.getDataTypeNameByCode(t.code));
             });
 
-            name += `<${nestedTypes.join(',')}>`;
-        } else if (type.info && type.info.name) {
-            name = type.info.name;
+
+            return name + `<${nestedTypes.join(',')}>`;
         }
 
-        return name;
+        return '';
+    }
+
+    _customType(colName) {
+        const type = this._getTypeDescription(colName);
+
+        if (type.info && type.info.name) {
+            return type.info.name;
+        }
+
+        return '';
+    }
+
+    _simpleType(colName) {
+        const type = this._getTypeDescription(colName);
+        return Metadata.getDataTypeNameByCode(type.code);
+    }
+
+
+    _getTypeDescription(colName) {
+        return this._md.columnsByName[colName].type;
     }
 
     /**

--- a/cassandra/lib/Metadata.js
+++ b/cassandra/lib/Metadata.js
@@ -1,0 +1,92 @@
+class Metadata {
+    constructor(md) {
+        this._md = md;
+    }
+
+    /**
+     * Returns true if JSON schema is the same as metadata of real schema
+     * @param {JSONSchema} jsonSchema
+     * @returns {boolean}
+     */
+    isSameColumnsSchema(jsonSchema) {
+        const schemaColumns = Object.keys(jsonSchema.getColumns()).map(col => col.toLowerCase());
+        const realTableColumns = Object.keys(this._md.columnsByName);
+
+        if (schemaColumns.length !== realTableColumns.length) {
+            return false;
+        }
+
+        return schemaColumns.every(col => realTableColumns.includes(col));
+    }
+
+    /**
+     * Returns true if column exists in this metadata
+     * @param {string} colName
+     * @returns {boolean}
+     */
+    columnExists(colName) {
+        return colName in this._md.columnsByName;
+    }
+
+    /**
+     * Returns full name of type with its types if type is complex
+     * @param {string} colName Column name
+     * @returns {string}
+     */
+    getColumnFullTypeName(colName) {
+        const type = this._md.columnsByName[colName].type;
+        let name = Metadata.getDataTypeNameByCode(type.code);
+
+        if (type.info && type.info.length) {
+            const nestedTypes = [];
+            type.info.forEach(t => {
+                nestedTypes.push(Metadata.getDataTypeNameByCode(t.code));
+            });
+
+            name += `<${nestedTypes.join(',')}>`;
+        } else if (type.info && type.info.name) {
+            name = type.info.name;
+        }
+
+        return name;
+    }
+
+    /**
+     * Returns data type name by given numeric code
+     * @param {Number} code
+     * @returns {string|undefined}
+     */
+    static getDataTypeNameByCode(code) {
+        return Metadata._dataTypesByCode[code];
+    }
+}
+
+Metadata._dataTypesByCode = {
+    1: 'ascii',
+    2: 'bigint',
+    3: 'blob',
+    4: 'boolean',
+    5: 'counter',
+    6: 'decimal',
+    7: 'double',
+    8: 'float',
+    9: 'int',
+    10: 'text',
+    11: 'timestamp',
+    12: 'uuid',
+    13: 'varchar',
+    14: 'varint',
+    15: 'timeuuid',
+    16: 'inet',
+    17: 'date',
+    18: 'time',
+    19: 'smallint',
+    20: 'tinyint',
+    32: 'list',
+    33: 'map',
+    34: 'set',
+    48: 'udt',
+    49: 'tuple'
+};
+
+module.exports = Metadata;

--- a/cassandra/lib/TableSchemaBuilder.js
+++ b/cassandra/lib/TableSchemaBuilder.js
@@ -2,13 +2,27 @@ const JSONSchema = require('./JSONSchema');
 const BaseSchemaBuilder = require('./BaseSchemaBuilder');
 
 class TableSchemaBuilder extends BaseSchemaBuilder {
+    constructor() {
+        super();
+        this._structureType = TableSchemaBuilder.TABLE_STRUCTURE;
+    }
+
     /**
-     * Specifies type of query
+     * Specifies create type of query
      * @param [tableName = '']
      * @returns {TableSchemaBuilder}
      */
     createTable(tableName = '') {
-        return this._create('TABLE', tableName);
+        return this._create(tableName);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [tableName = '']
+     * @returns {TableSchemaBuilder}
+     */
+    dropTable(tableName) {
+        return this._drop(tableName);
     }
 
     /**

--- a/cassandra/lib/UDTSchemaBuilder.js
+++ b/cassandra/lib/UDTSchemaBuilder.js
@@ -2,13 +2,27 @@ const JSONSchema = require('./JSONSchema');
 const BaseSchemaBuilder = require('./BaseSchemaBuilder');
 
 class UDTSchemaBuilder extends BaseSchemaBuilder {
+    constructor() {
+        super();
+        this._structureType = UDTSchemaBuilder.TYPE_STRUCTURE;
+    }
+
     /**
-     * Specifies type of query
+     * Specifies create type of query
      * @param [typeName = '']
      * @returns {UDTSchemaBuilder}
      */
     createType(typeName = '') {
-        return this._create('TYPE', typeName);
+        return this._create(typeName);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [typeName = '']
+     * @returns {UDTSchemaBuilder}
+     */
+    dropType(typeName) {
+        return this._drop(typeName);
     }
 
     /**

--- a/cassandra/lib/metadata/Metadata.js
+++ b/cassandra/lib/metadata/Metadata.js
@@ -28,44 +28,44 @@ class Metadata {
 
     /**
      * Returns true if column exists in this metadata
-     * @param {string} colName
+     * @param {string} propName
      * @returns {boolean}
      */
-    columnExists(colName) {
+    columnExists(propName) {
         throw new TypeError('columnExists() is not implemented');
     }
 
-    _getTypeDescription(colName) {
+    _getTypeDescription(propName) {
         throw new TypeError('_getTypeDescription() is not implemented');
     }
 
     /**
      * Returns true if JSON schema is the same as metadata of real schema (contains same members)
      * @param {JSONSchema} jsonSchema
-     * @param {Array<string>} structureMembers Array of member names of structure (table or UDT)
+     * @param {Array<string>} metadataProps Array of member names of structure (table or UDT)
      * @returns {boolean}
      * @private
      */
-    _sameStructure(jsonSchema, structureMembers) {
-        const schemaColumns = Object.keys(jsonSchema.getColumns()).map(col => col.toLowerCase());
+    _sameStructure(jsonSchema, metadataProps) {
+        const schemaProps = Object.keys(jsonSchema.getProperties()).map(prop => prop.toLowerCase());
 
-        if (schemaColumns.length !== structureMembers.length) {
+        if (schemaProps.length !== metadataProps.length) {
             return false;
         }
 
-        return schemaColumns.every(col => structureMembers.includes(col));
+        return schemaProps.every(prop => metadataProps.includes(prop));
     }
 
     /**
      * Returns full name of type with its types if type is complex
-     * @param {string} colName Column name
+     * @param {string} propName Field or column name
      * @returns {string}
      */
-    getColumnFullTypeName(colName) {
-        colName = colName.toLowerCase();
+    getFullTypeName(propName) {
+        propName = propName.toLowerCase();
         
-        const type = this._getTypeDescription(colName);
-        let name = this._complexType(colName) || this._customType(colName) || this._simpleType(colName);
+        const type = this._getTypeDescription(propName);
+        let name = this._complexType(propName) || this._customType(propName) || this._simpleType(propName);
 
         if (type.options && type.options.frozen) {
             name = `frozen<${name}>`;
@@ -74,8 +74,14 @@ class Metadata {
         return name;
     }
 
-    _complexType(colName) {
-        const type = this._getTypeDescription(colName);
+    /**
+     * Returns full definition of property type if it's complex type
+     * @param {string} propName Column or field name
+     * @returns {string}
+     * @private
+     */
+    _complexType(propName) {
+        const type = this._getTypeDescription(propName);
 
         if (type.info && type.info.length) {
             const name = Metadata.getDataTypeNameByCode(type.code);
@@ -92,8 +98,14 @@ class Metadata {
         return '';
     }
 
-    _customType(colName) {
-        const type = this._getTypeDescription(colName);
+    /**
+     * Returns custom type name if property is UDT
+     * @param {string} propName Column or field name
+     * @returns {string}
+     * @private
+     */
+    _customType(propName) {
+        const type = this._getTypeDescription(propName);
 
         if (type.info && type.info.name) {
             return type.info.name;
@@ -102,8 +114,14 @@ class Metadata {
         return '';
     }
 
-    _simpleType(colName) {
-        const type = this._getTypeDescription(colName);
+    /**
+     * Returns just type name if property field is simple type
+     * @param {string} propName Column or field name
+     * @returns {string}
+     * @private
+     */
+    _simpleType(propName) {
+        const type = this._getTypeDescription(propName);
         return Metadata.getDataTypeNameByCode(type.code);
     }
 

--- a/cassandra/lib/metadata/Metadata.js
+++ b/cassandra/lib/metadata/Metadata.js
@@ -62,6 +62,8 @@ class Metadata {
      * @returns {string}
      */
     getColumnFullTypeName(colName) {
+        colName = colName.toLowerCase();
+        
         const type = this._getTypeDescription(colName);
         let name = this._complexType(colName) || this._customType(colName) || this._simpleType(colName);
 

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -7,6 +7,7 @@ class TableMetadata extends Metadata {
     }
 
     columnExists(colName) {
+        colName = colName.toLowerCase();
         return colName in this._md.columnsByName;
     }
 

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -1,0 +1,18 @@
+const Metadata = require('./Metadata');
+
+class TableMetadata extends Metadata {
+    isSameMembersSchema(jsonSchema) {
+        const columns = Object.keys(this._md.columnsByName);
+        return this._sameStructure(jsonSchema, columns);
+    }
+
+    columnExists(colName) {
+        return colName in this._md.columnsByName;
+    }
+
+    _getTypeDescription(colName) {
+        return this._md.columnsByName[colName].type;
+    }
+}
+
+module.exports = TableMetadata;

--- a/cassandra/lib/metadata/UDTMetadata.js
+++ b/cassandra/lib/metadata/UDTMetadata.js
@@ -7,6 +7,7 @@ class UDTMetadata extends Metadata {
     }
 
     columnExists(colName) {
+        colName = colName.toLowerCase();
         return this._md.fields.some(f => f.name === colName);
     }
 

--- a/cassandra/lib/metadata/UDTMetadata.js
+++ b/cassandra/lib/metadata/UDTMetadata.js
@@ -1,0 +1,18 @@
+const Metadata = require('./Metadata');
+
+class UDTMetadata extends Metadata {
+    isSameMembersSchema(jsonSchema) {
+        const fields = this._md.fields.map(f => f.name);
+        return this._sameStructure(jsonSchema, fields);
+    }
+
+    columnExists(colName) {
+        return this._md.fields.some(f => f.name === colName);
+    }
+
+    _getTypeDescription(colName) {
+        return this._md.fields.filter(f => f.name === colName)[0].type;
+    }
+}
+
+module.exports = UDTMetadata;

--- a/cassandra/lib/metadata/index.js
+++ b/cassandra/lib/metadata/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./Metadata');

--- a/cassandra/src/CassandraConfigurator.js
+++ b/cassandra/src/CassandraConfigurator.js
@@ -106,7 +106,7 @@ class CassandraConfigurator {
             } else {
                 value = config[key] && Utils.booleanOrDefault(config[key].toString().trim());
                 if (value.includes && value.includes(',')) {
-                    value = value.split(',').map(str => str.trim());
+                    value = value.split(',').map(str => str.trim()).filter(str => Utils.isNotEmpty(str));
                 }
             }
 

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -1,4 +1,7 @@
+const EventEmitter = require('events');
+
 const Utils = require('../lib/Utils');
+const JSONSchema = require('../lib/JSONSchema');
 const CQLBuilder = require('../lib/CQLBuilder');
 
 class CassandraStorage {
@@ -202,92 +205,39 @@ class CassandraStorage {
         return this;
     }
 
-    compareTableSchemas(tableSchemas) {
-        const eventEmitter = new (require('events'))();
+    compareTableSchemas() {
+        const notifier = new EventEmitter();
 
-        for (let tableName in tableSchemas) {
-            if (tableSchemas.hasOwnProperty(tableName)) {
-                this._cassandra.metadata.getTable(this._cassandra.keyspace, tableName).then(md => {
-                    eventEmitter.emit('tableExists', tableName);
+        const requests = this._requestMetadata(this._tableSchemas);
 
-                    const tableSchema = tableSchemas[tableName];
-
-                    if (!this._sameColumnsSet(tableSchema, md)) {
-                        eventEmitter.emit('columnsMismatch', tableName);
-                    }
-
-                    this._compareColumnTypes(tableSchema, md).forEach(mismatch => {
-                        const mismatchDetails = [ tableName, mismatch.colName, mismatch.realType, mismatch.schemaType ];
-                        eventEmitter.emit('columnTypesMismatch', ...mismatchDetails);
-                    });
-                });
-            }
-        }
-
-        return eventEmitter;
-    }
-
-    _sameColumnsSet(tableSchema, metadata) {
-        const schemaColumns = Object.keys(tableSchema);
-        const realTableColumns = Object.keys(metadata.columnsByName);
-
-        if (schemaColumns.length !== realTableColumns.length) {
-            return false;
-        }
-
-        return schemaColumns.every(col => realTableColumns.includes(col));
-    }
-
-    _compareColumnTypes(tableSchema, metadata) {
-        const result = [];
-
-        for (let colName in tableSchema) {
-            if (colName in metadata.columnsByName) {
-                const { type: dataType } = metadata.columnsByName[colName];
-                const realType = this._getTypeNameByCode(dataType.code);
-                const schemaType = tableSchema[colName];
-
-                if (realType !== schemaType) {
-                    result.push({
-                        colName,
-                        realType,
-                        schemaType
-                    });
+        requests.forEach(metadataRequest => {
+            metadataRequest.then(md => {
+                if (!md) {
+                    return;
                 }
-            }
-        }
 
-        return result;
-    }
+                const tableName = md.name;
 
-    _getTypeNameByCode(code) {
-        return ({
-            1: 'ascii',
-            2: 'bigint',
-            3: 'blob',
-            4: 'boolean',
-            5: 'counter',
-            6: 'decimal',
-            7: 'double',
-            8: 'float',
-            9: 'int',
-            10: 'text',
-            11: 'timestamp',
-            12: 'uuid',
-            13: 'varchar',
-            14: 'varint',
-            15: 'timeuuid',
-            16: 'inet',
-            17: 'date',
-            18: 'time',
-            19: 'smallint',
-            20: 'tinyint',
-            32: 'list',
-            33: 'map',
-            34: 'set',
-            48: 'udt',
-            49: 'tuple'
-        })[code];
+                notifier.emit('tableExists', tableName);
+
+                const tableSchema = new JSONSchema(this._tableSchemas[tableName]);
+
+                if (!tableSchema.compareColumnsSetWithMetadata(md)) {
+                    notifier.emit('columnsMismatch', tableName);
+                }
+
+                tableSchema.diffColumnTypesWithMetadata(md).forEach(mismatch => {
+                    const mismatchDetails = [ tableName, mismatch.colName, mismatch.realType, mismatch.schemaType ];
+                    notifier.emit('columnTypesMismatch', ...mismatchDetails);
+                });
+            });
+        });
+
+        Promise.all(requests).then(() => {
+            notifier.emit('done');
+        });
+
+        return notifier;
     }
 
     /**

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -242,12 +242,12 @@ class CassandraStorage {
 
                 const schema = new JSONSchema(schemas[name]);
 
-                if (!schema.compareColumnsSetWithMetadata(md)) {
+                if (!schema.comparePropertySetWithMetadata(md)) {
                     notifier.notifyStructureMismatch(name);
                 }
 
-                schema.diffColumnTypesWithMetadata(md).forEach(mismatch => {
-                    const mismatchDetails = [ name, mismatch.colName, mismatch.realType, mismatch.schemaType ];
+                schema.diffPropertyTypesWithMetadata(md).forEach(mismatch => {
+                    const mismatchDetails = [ name, mismatch.propName, mismatch.realType, mismatch.schemaType ];
                     notifier.notifyTypesMismatch(...mismatchDetails);
                 });
             });

--- a/cassandra/src/SchemaComparisonNotifier.js
+++ b/cassandra/src/SchemaComparisonNotifier.js
@@ -1,0 +1,22 @@
+const EventEmitter = require('events');
+
+class SchemaComparisonNotifier extends EventEmitter {
+    constructor(events) {
+        super();
+        this._events = events;
+    }
+
+    notifyExistence(name) {
+        return this.emit(this._events.exists, name);
+    }
+
+    notifyStructureMismatch(name) {
+        return this.emit(this._events.structureMismatch, name);
+    }
+
+    notifyTypesMismatch(...mismatchDetails) {
+        return this.emit(this._events.typesMismatch, ...mismatchDetails);
+    }
+}
+
+module.exports = SchemaComparisonNotifier;

--- a/cassandraSchemas/cassandra-tables.json
+++ b/cassandraSchemas/cassandra-tables.json
@@ -2,10 +2,10 @@
   "tables": {
     "commands": {
       "command": "text",
-      "deviceId": "text",
+      "deviceId": "int",
       "timestamp": "timestamp",
       "id": "int",
-      "parameters": "map<text,text>",
+      "parameters": "frozen<params>",
 
       "__primaryKey__": [ "command", "deviceId" ],
       "__clusteredKey__": [ "timestamp" ],

--- a/cassandraSchemas/cassandra-tables.json
+++ b/cassandraSchemas/cassandra-tables.json
@@ -2,7 +2,7 @@
   "tables": {
     "commands": {
       "command": "text",
-      "deviceId": "int",
+      "deviceId": "text",
       "timestamp": "timestamp",
       "id": "int",
       "parameters": "frozen<params>",

--- a/cassandraSchemas/cassandra-tables.json
+++ b/cassandraSchemas/cassandra-tables.json
@@ -5,7 +5,7 @@
       "deviceId": "text",
       "timestamp": "timestamp",
       "id": "int",
-      "parameters": "text",
+      "parameters": "map<text,text>",
 
       "__primaryKey__": [ "command", "deviceId" ],
       "__clusteredKey__": [ "timestamp" ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - schema
     volumes:
-      - .\cassandraSchemas\:/usr/src/app/cassandraSchemas
+      - ./cassandraSchemas/:/usr/src/app/cassandraSchemas
   schema:
     build:
       context: .
@@ -18,4 +18,4 @@ services:
     env_file:
       - .env
     volumes:
-      - .\cassandraSchemas\:/usr/src/app/cassandraSchemas
+      - ./cassandraSchemas/:/usr/src/app/cassandraSchemas

--- a/plugin/CassandraPluginService.js
+++ b/plugin/CassandraPluginService.js
@@ -1,9 +1,7 @@
 const PluginService = require('./PluginService');
+const cassandraInit = require('./cassandraInit');
 
 const cassandraConfig = require(`./config`).cassandra;
-const cassandraTables = require('../cassandraSchemas/cassandra-tables');
-const cassandraUDTs = require('../cassandraSchemas/cassandra-user-types');
-const CassandraStorage = require('../cassandra');
 
 /**
  * Cassandra Plugin main class
@@ -45,93 +43,7 @@ class CassandraPluginService extends PluginService {
     }
 
     initCassandra() {
-        return CassandraStorage.connect(cassandraConfig).then(cassandra => {
-            cassandra.setUDTSchemas(cassandraUDTs)
-                .setTableSchemas(cassandraTables.tables)
-                .assignTablesToCommands(...cassandraTables.commandTables)
-                .assignTablesToCommandUpdates(...cassandraTables.commandUpdatesTables)
-                .assignTablesToNotifications(...cassandraTables.notificationTables);
-
-            return this._schemaComparison(cassandra);
-        }).then(cassandra => this.ensureSchemasExist(cassandra));
-    }
-
-    ensureSchemasExist(cassandra) {
-        return new Promise((resolve, reject) => {
-            const interval = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_INTERVAL) || 1000;
-            const schemaCheck = this._createSchemaChecking(cassandra);
-            const checking = setInterval(() => {
-                schemaCheck().then(ok => {
-                    if (ok) {
-                        clearInterval(checking);
-                        resolve(cassandra);
-                    }
-                }).catch(err => {
-                    clearInterval(checking);
-                    reject(err);
-                });
-            }, interval);
-        });
-    }
-
-    _createSchemaChecking(cassandra) {
-        let checkNumber = 0;
-        const checksThreshold = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_COUNT) || 0;
-        return () => {
-            return new Promise((resolve, reject) => {
-                if (checkNumber >= checksThreshold) {
-                    reject(new Error('CASSANDRA SCHEMAS HAVE NOT BEEN CREATED'));
-                    return;
-                }
-
-                checkNumber++;
-                cassandra.checkSchemasExistence(resolve);
-            });
-        };
-    }
-
-    _schemaComparison(cassandra) {
-        const tableComparisonNotifier = cassandra.compareTableSchemas();
-        const udtComparisonNotifier = cassandra.compareUDTSchemas();
-        const errorMsg = 'Schema mismatch, please check your JSON schemas of UDTs, tables and actual schemas in Cassandra';
-
-        const tableComparison = new Promise((resolve, reject) => {
-            let ok = true;
-
-            tableComparisonNotifier.on('columnsMismatch', tableName => {
-                console.log(`TABLE ${tableName}: Mismatched schema`);
-                ok = false;
-            }).on('columnTypesMismatch', (tableName, colName, realType, schemaType) => {
-                console.log(`TABLE ${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
-                ok = false;
-            }).on('done', () => {
-                if (ok) {
-                    resolve();
-                } else {
-                    reject(new Error(errorMsg));
-                }
-            });
-        });
-
-        const udtComparison = new Promise((resolve, reject) => {
-            let ok = true;
-
-            udtComparisonNotifier.on('fieldsMismatch', udtName => {
-                console.log(`UDT ${udtName}: Mismatched schema`);
-                ok = false;
-            }).on('fieldTypesMismatch', (udtName, fieldName, realType, schemaType) => {
-                console.log(`UDT ${udtName}: Mismatched ${fieldName} type, actual "${realType}", in JSON schema "${schemaType}"`);
-                ok = false;
-            }).on('done', () => {
-                if (ok) {
-                    resolve();
-                } else {
-                    reject(new Error(errorMsg));
-                }
-            });
-        });
-
-        return Promise.all([ tableComparison, udtComparison ]).then(() => cassandra);
+        return cassandraInit();
     }
 }
 

--- a/plugin/CassandraPluginService.js
+++ b/plugin/CassandraPluginService.js
@@ -58,7 +58,7 @@ class CassandraPluginService extends PluginService {
 
     ensureSchemasExist(cassandra) {
         return new Promise((resolve, reject) => {
-            const interval = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_INTERVAL) || 0;
+            const interval = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_INTERVAL) || 1000;
             const schemaCheck = this._createSchemaChecking(cassandra);
             const checking = setInterval(() => {
                 schemaCheck().then(ok => {

--- a/plugin/cassandraInit.js
+++ b/plugin/cassandraInit.js
@@ -1,0 +1,96 @@
+const cassandraConfig = require(`./config`).cassandra;
+const cassandraTables = require('../cassandraSchemas/cassandra-tables');
+const cassandraUDTs = require('../cassandraSchemas/cassandra-user-types');
+const CassandraStorage = require('../cassandra');
+
+function initCassandra() {
+    return CassandraStorage.connect(cassandraConfig).then(cassandra => {
+        cassandra.setUDTSchemas(cassandraUDTs)
+            .setTableSchemas(cassandraTables.tables)
+            .assignTablesToCommands(...cassandraTables.commandTables)
+            .assignTablesToCommandUpdates(...cassandraTables.commandUpdatesTables)
+            .assignTablesToNotifications(...cassandraTables.notificationTables);
+
+        return schemaComparison(cassandra);
+    }).then(cassandra => ensureSchemasExist(cassandra));
+}
+
+function ensureSchemasExist(cassandra) {
+    return new Promise((resolve, reject) => {
+        const interval = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_INTERVAL) || 1000;
+        const schemaCheck = createSchemaChecking(cassandra);
+        const checking = setInterval(() => {
+            schemaCheck().then(ok => {
+                if (ok) {
+                    clearInterval(checking);
+                    resolve(cassandra);
+                }
+            }).catch(err => {
+                clearInterval(checking);
+                reject(err);
+            });
+        }, interval);
+    });
+}
+
+function createSchemaChecking(cassandra) {
+    let checkNumber = 0;
+    const checksThreshold = Number(cassandraConfig.CUSTOM.SCHEMA_CHECKS_COUNT) || 0;
+    return () => {
+        return new Promise((resolve, reject) => {
+            if (checkNumber >= checksThreshold) {
+                reject(new Error('CASSANDRA SCHEMAS HAVE NOT BEEN CREATED'));
+                return;
+            }
+
+            checkNumber++;
+            cassandra.checkSchemasExistence(resolve);
+        });
+    };
+}
+
+function schemaComparison(cassandra) {
+    const tableComparisonNotifier = cassandra.compareTableSchemas();
+    const udtComparisonNotifier = cassandra.compareUDTSchemas();
+    const errorMsg = 'Schema mismatch, please check your JSON schemas of UDTs, tables and actual schemas in Cassandra';
+
+    const tableComparison = new Promise((resolve, reject) => {
+        let ok = true;
+
+        tableComparisonNotifier.on('columnsMismatch', tableName => {
+            console.log(`TABLE ${tableName}: Mismatched schema`);
+            ok = false;
+        }).on('columnTypesMismatch', (tableName, colName, realType, schemaType) => {
+            console.log(`TABLE ${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
+            ok = false;
+        }).on('done', () => {
+            if (ok) {
+                resolve();
+            } else {
+                reject(new Error(errorMsg));
+            }
+        });
+    });
+
+    const udtComparison = new Promise((resolve, reject) => {
+        let ok = true;
+
+        udtComparisonNotifier.on('fieldsMismatch', udtName => {
+            console.log(`UDT ${udtName}: Mismatched schema`);
+            ok = false;
+        }).on('fieldTypesMismatch', (udtName, fieldName, realType, schemaType) => {
+            console.log(`UDT ${udtName}: Mismatched ${fieldName} type, actual "${realType}", in JSON schema "${schemaType}"`);
+            ok = false;
+        }).on('done', () => {
+            if (ok) {
+                resolve();
+            } else {
+                reject(new Error(errorMsg));
+            }
+        });
+    });
+
+    return Promise.all([ tableComparison, udtComparison ]).then(() => cassandra);
+}
+
+module.exports = initCassandra;

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -6,33 +6,56 @@ class SchemaCreator {
     }
 
     create({ udt, tables }) {
-        const schemaComparison = this._client.setTableSchemas(tables).compareTableSchemas();
-        const comparison = this._resolveSchemaComparison(schemaComparison);
+        const tableComparisonNotifier = this._client.setTableSchemas(tables).compareTableSchemas();
+        const udtComparisonNotifier = this._client.setUDTSchemas(udt).compareUDTSchemas();
+        const comparison = this._resolveSchemaComparison(tableComparisonNotifier, udtComparisonNotifier);
 
         return comparison.then(() => this._client.createUDTSchemas(udt))
             .then(() => this._client.createTableSchemas(tables));
     }
 
-    _resolveSchemaComparison(comparison) {
-        return new Promise((resolve, reject) => {
+    _resolveSchemaComparison(tableComparisonNotifier, udtComparisonNotifier) {
+        const tableComparison = new Promise((resolve, reject) => {
             let ok = true;
 
-            comparison.on('tableExists', tableName => {
-                console.log(`${tableName}: Table already exists`);
+            tableComparisonNotifier.on('tableExists', tableName => {
+                console.log(`TABLE ${tableName}: Table already exists`);
             }).on('columnsMismatch', tableName => {
-                console.log(`${tableName}: Mismatched schema`);
+                console.log(`TABLE ${tableName}: Mismatched schema`);
                 ok = false;
             }).on('columnTypesMismatch', (tableName, colName, realType, schemaType) => {
-                console.log(`${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
+                console.log(`TABLE ${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
                 ok = false;
             }).on('done', () => {
                 if (ok) {
                     resolve();
                 } else {
-                    reject(SchemaError.schemaMismatch());
+                    reject(SchemaError.tableSchemaMismatch());
                 }
             });
         });
+
+        const udtComparison = new Promise((resolve, reject) => {
+            let ok = true;
+
+            udtComparisonNotifier.on('customTypeExists', udtName => {
+                console.log(`UDT ${udtName}: UDT already exists`);
+            }).on('fieldsMismatch', udtName => {
+                console.log(`UDT ${udtName}: Mismatched schema`);
+                ok = false;
+            }).on('fieldTypesMismatch', (udtName, fieldName, realType, schemaType) => {
+                console.log(`UDT ${udtName}: Mismatched ${fieldName} type, actual "${realType}", in JSON schema "${schemaType}"`);
+                ok = false;
+            }).on('done', () => {
+                if (ok) {
+                    resolve();
+                } else {
+                    reject(SchemaError.udtSchemaMismatch());
+                }
+            });
+        });
+
+        return Promise.all([ tableComparison, udtComparison ]);
     }
 
     static getSchemasErrors(tableSchemas) {

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -14,6 +14,10 @@ class SchemaCreator {
             .then(() => this._client.createTableSchemas(tables));
     }
 
+    dropBeforeCreate({ udt, tables }) {
+        return this._client.dropTableSchemas(tables).then(() => this._client.dropTypeSchemas(udt));
+    }
+
     _resolveSchemaComparison(tableComparisonNotifier, udtComparisonNotifier) {
         const tableComparison = new Promise((resolve, reject) => {
             let ok = true;

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -7,10 +7,10 @@ class SchemaCreator {
 
     create({ udt, tables }) {
         const schemaComparison = this._client.setTableSchemas(tables).compareTableSchemas();
-
         const comparison = this._resolveSchemaComparison(schemaComparison);
 
-        return comparison.then(() => this._client.createUDTSchemas(udt)).then(() => this._client.createTableSchemas(tables));
+        return comparison.then(() => this._client.createUDTSchemas(udt))
+            .then(() => this._client.createTableSchemas(tables));
     }
 
     _resolveSchemaComparison(comparison) {

--- a/plugin/cassandraSchema/SchemaError.js
+++ b/plugin/cassandraSchema/SchemaError.js
@@ -1,5 +1,5 @@
 class SchemaError extends Error {
-    constructor(tableName, field, message) {
+    constructor(tableName, message) {
         super();
 
         this.tableName = tableName;
@@ -12,7 +12,11 @@ class SchemaError extends Error {
     }
 
     static parametersError(tableName) {
-        return new SchemaError(tableName, 'parameters', 'parameters field is not allowed type');
+        return new SchemaError(tableName, 'parameters field is not allowed type');
+    }
+
+    static schemaMismatch() {
+        return new SchemaError(null, 'Schema mismatch, please check your JSON schemas of tables and actual schemas in Casasndra');
     }
 }
 

--- a/plugin/cassandraSchema/SchemaError.js
+++ b/plugin/cassandraSchema/SchemaError.js
@@ -15,8 +15,12 @@ class SchemaError extends Error {
         return new SchemaError(tableName, 'parameters field is not allowed type');
     }
 
-    static schemaMismatch() {
-        return new SchemaError(null, 'Schema mismatch, please check your JSON schema of tables and actual schemas in Cassandra');
+    static tableSchemaMismatch() {
+        return new SchemaError(null, 'Table schema mismatch, please check your JSON schema of tables and actual schemas in Cassandra');
+    }
+
+    static udtSchemaMismatch() {
+        return new SchemaError(null, 'UDT schema mismatch, please check your JSON schema of UDTs and actual schemas in Cassandra');
     }
 }
 

--- a/plugin/cassandraSchema/SchemaError.js
+++ b/plugin/cassandraSchema/SchemaError.js
@@ -16,7 +16,7 @@ class SchemaError extends Error {
     }
 
     static schemaMismatch() {
-        return new SchemaError(null, 'Schema mismatch, please check your JSON schemas of tables and actual schemas in Casasndra');
+        return new SchemaError(null, 'Schema mismatch, please check your JSON schema of tables and actual schemas in Cassandra');
     }
 }
 

--- a/plugin/cassandraSchema/index.js
+++ b/plugin/cassandraSchema/index.js
@@ -16,12 +16,16 @@ createSchema().then(() => {
 });
 
 function createSchema() {
+    const schemas = {
+        udt: cassandraUDTs,
+        tables: cassandraTables.tables
+    };
+    let schemaCreator;
+
     return CassandraStorage.connect(cassandraConfig).then(cassandra => {
-        return new SchemaCreator(cassandra).create({
-            udt: cassandraUDTs,
-            tables: cassandraTables.tables
-        });
-    });
+        schemaCreator = new SchemaCreator(cassandra);
+        return schemaCreator.dropBeforeCreate(schemas);
+    }).then(() => schemaCreator.create(schemas));
 }
 
 function exitIfInvalid(schemas) {

--- a/test/cassandra/dataBuilders/MetadataBuilder.js
+++ b/test/cassandra/dataBuilders/MetadataBuilder.js
@@ -1,6 +1,18 @@
 const DataBuilder = require('smp-data-builder');
 
 class MetadataBuilder extends DataBuilder {
+    withColumnTypeOption(columnName, optName, optVal) {
+        const type = this.obj.columnsByName[columnName].type;
+
+        if (!type.options) {
+            type.options = {};
+        }
+
+        type.options[optName] = optVal;
+
+        return this;
+    }
+
     withColumnNestedType(columnName, typeCode) {
         const type = this.obj.columnsByName[columnName].type;
 

--- a/test/cassandra/dataBuilders/MetadataBuilder.js
+++ b/test/cassandra/dataBuilders/MetadataBuilder.js
@@ -1,0 +1,33 @@
+const DataBuilder = require('smp-data-builder');
+
+class MetadataBuilder extends DataBuilder {
+    withColumnNestedType(columnName, typeCode) {
+        const type = this.obj.columnsByName[columnName].type;
+
+        if (!(type.info instanceof Array)) {
+            type.info = [];
+        }
+
+        type.info.push({ code: typeCode });
+
+        return this;
+    }
+
+    withColumnTypeName(columnName, typeName) {
+        this.obj.columnsByName[columnName].type.info.name = typeName;
+        return this;
+    }
+
+    withColumn(name, typeCode, info = {}) {
+        return this.with('columnsByName', {
+            [name]: {
+                type: {
+                    code: typeCode,
+                    info
+                }
+            }
+        });
+    }
+}
+
+module.exports = MetadataBuilder;

--- a/test/cassandra/dataBuilders/TableMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/TableMetadataBuilder.js
@@ -13,6 +13,11 @@ class TableMetadataBuilder extends DataBuilder {
         return this;
     }
 
+    withColumnNestedTextType(columnName) {
+        const TEXT_TYPE_CODE = 10;
+        return this.withColumnNestedType(columnName, TEXT_TYPE_CODE);
+    }
+
     withColumnNestedType(columnName, typeCode) {
         const type = this.obj.columnsByName[columnName].type;
 
@@ -28,6 +33,16 @@ class TableMetadataBuilder extends DataBuilder {
     withColumnTypeName(columnName, typeName) {
         this.obj.columnsByName[columnName].type.info.name = typeName;
         return this;
+    }
+
+    withMapColumn(name) {
+        const MAP_TYPE_CODE = 33;
+        return this.withColumn(name, MAP_TYPE_CODE);
+    }
+
+    withUDTColumn(name) {
+        const UDT_TYPE_CODE = 48;
+        return this.withColumn(name, UDT_TYPE_CODE);
     }
 
     withTextColumn(name) {

--- a/test/cassandra/dataBuilders/TableMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/TableMetadataBuilder.js
@@ -1,6 +1,6 @@
 const DataBuilder = require('smp-data-builder');
 
-class MetadataBuilder extends DataBuilder {
+class TableMetadataBuilder extends DataBuilder {
     withColumnTypeOption(columnName, optName, optVal) {
         const type = this.obj.columnsByName[columnName].type;
 
@@ -30,16 +30,31 @@ class MetadataBuilder extends DataBuilder {
         return this;
     }
 
+    withTextColumn(name) {
+        const TEXT_TYPE_CODE = 10;
+        return this.withColumn(name, TEXT_TYPE_CODE);
+    }
+
+    withIntColumn(name) {
+        const INT_TYPE_CODE = 9;
+        return this.withColumn(name, INT_TYPE_CODE);
+    }
+
     withColumn(name, typeCode, info = {}) {
         return this.with('columnsByName', {
             [name]: {
                 type: {
                     code: typeCode,
                     info
-                }
+                },
+                name
             }
         });
     }
+
+    withName(name) {
+        return this.with('name', name);
+    }
 }
 
-module.exports = MetadataBuilder;
+module.exports = TableMetadataBuilder;

--- a/test/cassandra/dataBuilders/UDTMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/UDTMetadataBuilder.js
@@ -1,0 +1,28 @@
+const DataBuilder = require('smp-data-builder');
+
+class UDTMetadataBuilder extends DataBuilder {
+    withTextField(name) {
+        const TEXT_TYPE_CODE = 10;
+        return this.withField(name, TEXT_TYPE_CODE);
+    }
+
+    withIntField(name) {
+        const INT_TYPE_CODE = 9;
+        return this.withField(name, INT_TYPE_CODE);
+    }
+
+    withField(name, typeCode) {
+        return this.with('fields', [ {
+            type: {
+                code: typeCode
+            },
+            name
+        } ]);
+    }
+
+    withName(name) {
+        return this.with('name', name);
+    }
+}
+
+module.exports = UDTMetadataBuilder;

--- a/test/cassandra/lib/CassandraUtils.js
+++ b/test/cassandra/lib/CassandraUtils.js
@@ -12,4 +12,30 @@ describe('Cassandra Utils', () => {
         const typeName = CassandraUtils.extractTypeName('FROZEN<test_custom_type>');
         assert.equal(typeName, 'test_custom_type');
     });
+
+    it('Should cast value to string if Cassandra type is text, ascii or varchar', () => {
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('text', 123), '123');
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('ascii', 123), '123');
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('varchar', 123), '123');
+    });
+
+    it('Should stringify to JSON object if Cassandra type is text, ascii or varchar', () => {
+        const obj = { prop: 'test' };
+        const stringified = JSON.stringify(obj);
+
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('text', obj), stringified);
+    });
+
+    it('Should return null if second argument (value) for cassandraStringTypeOrDefault is null or undefined', () => {
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('text'), null);
+        assert.strictEqual(CassandraUtils.cassandraStringTypeOrDefault('text', null), null);
+    });
+
+    it('Should replace "varchar" alias with "text"', () => {
+        const simpleType = 'varchar';
+        const complexType = 'frozen<map<varchar,varchar>>';
+
+        assert.equal(CassandraUtils.replaceTypeAliases(simpleType), 'text');
+        assert.equal(CassandraUtils.replaceTypeAliases(complexType), 'frozen<map<text,text>>');
+    });
 });

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -174,7 +174,7 @@ describe('JSON Schema', () => {
 
         const schema = new JSONSchema({
             id: 'int',
-            col1: 'text',
+            Col1: 'text',
             __primaryKey__: [ 'id' ]
         });
         const metadata = new MetadataBuilder().withColumn('id', TEXT_TYPE_CODE).withColumn('col1', INT_TYPE_CODE).build();
@@ -188,7 +188,7 @@ describe('JSON Schema', () => {
                 schemaType: 'int'
             },
             {
-                colName: 'col1',
+                colName: 'Col1',
                 realType: 'int',
                 schemaType: 'text'
             }

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -250,4 +250,13 @@ describe('JSON Schema', () => {
 
         assert.equal(mismatches.length, 0);
     });
+
+    it('Should return false for shouldBeDropped() if __dropIfExists__ is absent in schema', () => {
+        const schema = new JSONSchema({
+            id: 'int',
+            __primaryKey__: [ 'id' ]
+        });
+
+        assert.strictEqual(schema.shouldBeDropped(), false);
+    });
 });

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -82,24 +82,6 @@ describe('JSON Schema', () => {
         assert.equal(jsonSchema.filterData(null), null);
     });
 
-    it('Should cast value to string if Cassandra type is text, ascii or varchar', () => {
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', 123), '123');
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('ascii', 123), '123');
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('varchar', 123), '123');
-    });
-
-    it('Should stringify to JSON object if Cassandra type is text, ascii or varchar', () => {
-        const obj = { prop: 'test' };
-        const stringified = JSON.stringify(obj);
-
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', obj), stringified);
-    });
-
-    it('Should return null if second argument (value) for cassandraStringTypeOrDefault is null or undefined', () => {
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text'), null);
-        assert.strictEqual(JSONSchema.cassandraStringTypeOrDefault('text', null), null);
-    });
-
     it('Should return filtered object consisted of primary and clustered keys only', () => {
         const schema = new JSONSchema({
             id: 'int',
@@ -270,5 +252,20 @@ describe('JSON Schema', () => {
         const mismatches = schema.diffColumnTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 1);
+    });
+
+    it('Should treat varchar as text in basic types and return 0 mismatches', () => {
+        const TEXT_TYPE_CODE = 10;
+
+        const schema = new JSONSchema({
+            field1: 'varchar'
+        });
+
+        const mdBuilder = new MetadataBuilder().withColumn('field1', TEXT_TYPE_CODE);
+        const metadata = mdBuilder.build();
+
+        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+
+        assert.equal(mismatches.length, 0);
     });
 });

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -151,15 +151,12 @@ describe('JSON Schema', () => {
     });
 
     it('Should return array of mismatches in case some column types of schema do not match columns in metadata', () => {
-        const TEXT_TYPE_CODE = 10;
-        const INT_TYPE_CODE = 9;
-
         const schema = new JSONSchema({
             id: 'int',
             Col1: 'text',
             __primaryKey__: [ 'id' ]
         });
-        const metadata = new MetadataBuilder().withColumn('id', TEXT_TYPE_CODE).withColumn('col1', INT_TYPE_CODE).build();
+        const metadata = new MetadataBuilder().withTextColumn('id').withIntColumn('col1').build();
 
         const mismatches = schema.diffColumnTypesWithMetadata(metadata);
 
@@ -179,17 +176,13 @@ describe('JSON Schema', () => {
     });
 
     it('Should NOT return any mismatches in case column types are map with same key and value types', () => {
-        const MAP_TYPE_CODE = 33;
-        const TEXT_TYPE_CODE = 10;
-        const INT_TYPE_CODE = 9;
-
         const schema = new JSONSchema({
             id: 'int',
             col1: 'map<text,text>',
             __primaryKey__: [ 'id' ]
         });
-        const mdBuilder = new MetadataBuilder().withColumn('id', INT_TYPE_CODE).withColumn('col1', MAP_TYPE_CODE);
-        mdBuilder.withColumnNestedType('col1', TEXT_TYPE_CODE).withColumnNestedType('col1', TEXT_TYPE_CODE);
+        const mdBuilder = new MetadataBuilder().withIntColumn('id').withMapColumn('col1');
+        mdBuilder.withColumnNestedTextType('col1').withColumnNestedTextType('col1');
         const metadata = mdBuilder.build();
 
         const mismatches = schema.diffColumnTypesWithMetadata(metadata);
@@ -198,16 +191,13 @@ describe('JSON Schema', () => {
     });
 
     it('Should NOT return any mismatches in case columns are the same user defined type', () => {
-        const UDT_TYPE_CODE = 48;
-        const INT_TYPE_CODE = 9;
-
         const schema = new JSONSchema({
             id: 'int',
             col1: 'my_type',
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withColumn('id', INT_TYPE_CODE).withColumn('col1', UDT_TYPE_CODE);
+        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'my_type');
         const metadata = mdBuilder.build();
 
@@ -217,16 +207,13 @@ describe('JSON Schema', () => {
     });
 
     it('Should return mismatches in case columns are the same user defined type but in metadata type is frozen', () => {
-        const UDT_TYPE_CODE = 48;
-        const INT_TYPE_CODE = 9;
-
         const schema = new JSONSchema({
             id: 'int',
             col1: 'my_type',
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withColumn('id', INT_TYPE_CODE).withColumn('col1', UDT_TYPE_CODE);
+        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'my_type').withColumnTypeOption('col1', 'frozen', true);
         const metadata = mdBuilder.build();
 
@@ -236,16 +223,13 @@ describe('JSON Schema', () => {
     });
 
     it('Should return mismatches in case columns are NOT the same user defined type', () => {
-        const UDT_TYPE_CODE = 48;
-        const INT_TYPE_CODE = 9;
-
         const schema = new JSONSchema({
             id: 'int',
             col1: 'my_type',
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withColumn('id', INT_TYPE_CODE).withColumn('col1', UDT_TYPE_CODE);
+        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'another_type');
         const metadata = mdBuilder.build();
 
@@ -255,13 +239,11 @@ describe('JSON Schema', () => {
     });
 
     it('Should treat varchar as text in basic types and return 0 mismatches', () => {
-        const TEXT_TYPE_CODE = 10;
-
         const schema = new JSONSchema({
             field1: 'varchar'
         });
 
-        const mdBuilder = new MetadataBuilder().withColumn('field1', TEXT_TYPE_CODE);
+        const mdBuilder = new MetadataBuilder().withTextColumn('field1');
         const metadata = mdBuilder.build();
 
         const mismatches = schema.diffColumnTypesWithMetadata(metadata);

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const MetadataBuilder = require('../dataBuilders/MetadataBuilder');
+const MetadataBuilder = require('../dataBuilders/TableMetadataBuilder');
 
 const JSONSchema = require('../../../cassandra/lib/JSONSchema');
 

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -234,6 +234,25 @@ describe('JSON Schema', () => {
         assert.equal(mismatches.length, 0);
     });
 
+    it('Should return mismatches in case columns are the same user defined type but in metadata type is frozen', () => {
+        const UDT_TYPE_CODE = 48;
+        const INT_TYPE_CODE = 9;
+
+        const schema = new JSONSchema({
+            id: 'int',
+            col1: 'my_type',
+            __primaryKey__: [ 'id' ]
+        });
+
+        const mdBuilder = new MetadataBuilder().withColumn('id', INT_TYPE_CODE).withColumn('col1', UDT_TYPE_CODE);
+        mdBuilder.withColumnTypeName('col1', 'my_type').withColumnTypeOption('col1', 'frozen', true);
+        const metadata = mdBuilder.build();
+
+        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+
+        assert.equal(mismatches.length, 1);
+    });
+
     it('Should return mismatches in case columns are NOT the same user defined type', () => {
         const UDT_TYPE_CODE = 48;
         const INT_TYPE_CODE = 9;

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -137,7 +137,7 @@ describe('JSON Schema', () => {
         });
         const metadata = new MetadataBuilder().withColumn('id').build();
 
-        assert.equal(schema.compareColumnsSetWithMetadata(metadata), true);
+        assert.equal(schema.comparePropertySetWithMetadata(metadata), true);
     });
 
     it('Should return false if schema columns set is NOT same as columns in given metadata object', () => {
@@ -147,7 +147,7 @@ describe('JSON Schema', () => {
         });
         const metadata = new MetadataBuilder().withColumn('col1').build();
 
-        assert.equal(schema.compareColumnsSetWithMetadata(metadata), false);
+        assert.equal(schema.comparePropertySetWithMetadata(metadata), false);
     });
 
     it('Should return array of mismatches in case some column types of schema do not match columns in metadata', () => {
@@ -158,16 +158,16 @@ describe('JSON Schema', () => {
         });
         const metadata = new MetadataBuilder().withTextColumn('id').withIntColumn('col1').build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         const expected = [
             {
-                colName: 'id',
+                propName: 'id',
                 realType: 'text',
                 schemaType: 'int'
             },
             {
-                colName: 'Col1',
+                propName: 'Col1',
                 realType: 'int',
                 schemaType: 'text'
             }
@@ -185,7 +185,7 @@ describe('JSON Schema', () => {
         mdBuilder.withColumnNestedTextType('col1').withColumnNestedTextType('col1');
         const metadata = mdBuilder.build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 0);
     });
@@ -201,7 +201,7 @@ describe('JSON Schema', () => {
         mdBuilder.withColumnTypeName('col1', 'my_type');
         const metadata = mdBuilder.build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 0);
     });
@@ -217,7 +217,7 @@ describe('JSON Schema', () => {
         mdBuilder.withColumnTypeName('col1', 'my_type').withColumnTypeOption('col1', 'frozen', true);
         const metadata = mdBuilder.build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 1);
     });
@@ -233,7 +233,7 @@ describe('JSON Schema', () => {
         mdBuilder.withColumnTypeName('col1', 'another_type');
         const metadata = mdBuilder.build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 1);
     });
@@ -246,7 +246,7 @@ describe('JSON Schema', () => {
         const mdBuilder = new MetadataBuilder().withTextColumn('field1');
         const metadata = mdBuilder.build();
 
-        const mismatches = schema.diffColumnTypesWithMetadata(metadata);
+        const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
         assert.equal(mismatches.length, 0);
     });

--- a/test/cassandra/lib/TableSchemaBuilder.js
+++ b/test/cassandra/lib/TableSchemaBuilder.js
@@ -128,4 +128,14 @@ describe('Table Schema Builder', () => {
         const query = builder.build();
         assert.equal(query, expectedQuery);
     });
+
+    it('Should build DROP TABLE query', () => {
+        const query = new TableSchemaBuilder().dropTable('my_table').build();
+        assert.equal(query, 'DROP TABLE my_table');
+    });
+
+    it('Should build DROP TABLE query with IF EXISTS', () => {
+        const query = new TableSchemaBuilder().dropTable('my_table').ifExists().build();
+        assert.equal(query, 'DROP TABLE IF EXISTS my_table');
+    });
 });

--- a/test/cassandra/lib/UDTSchemaBuilder.js
+++ b/test/cassandra/lib/UDTSchemaBuilder.js
@@ -26,4 +26,14 @@ describe('User Defined Type Builder', () => {
 
         assert.equal(query, 'CREATE TYPE IF NOT EXISTS test(prop1 int)');
     });
+
+    it('Should build DROP TYPE query', () => {
+        const query = new UDTSchemaBuilder().dropType('test').build();
+        assert.equal(query, 'DROP TYPE test');
+    });
+
+    it('Should build DROP TABLE query with IF EXISTS', () => {
+        const query = new UDTSchemaBuilder().dropType('test').ifExists().build();
+        assert.equal(query, 'DROP TYPE IF EXISTS test');
+    });
 });

--- a/test/cassandra/src/CassandraConfigurator.js
+++ b/test/cassandra/src/CassandraConfigurator.js
@@ -136,7 +136,7 @@ describe('Cassandra Config', () => {
                 'CONNECT_TIMEOUT': '5000'
             },
             'CONTACT_POINTS': '127.0.0.1, 0.0.0.0',
-            'TEST_PROPERTY': 't,e,s,t'
+            'TEST_PROPERTY': 't,e,s,t,'
         };
 
         const expectedConf = {

--- a/test/cassandra/src/CassandraStorage.js
+++ b/test/cassandra/src/CassandraStorage.js
@@ -309,10 +309,10 @@ describe('Cassandra Storage Provider', () => {
         asyncAssertion(() => {
             assert.equal(eventEmitter.emit.callCount, 3, 'Number of times event was emitted');
 
-            const [ event, tableName, colName, realType, schemaType ] = eventEmitter.emit.secondCall.args;
+            const [ event, tableName, propName, realType, schemaType ] = eventEmitter.emit.secondCall.args;
             assert.equal(event, 'columnTypesMismatch');
             assert.equal(tableName, 'testTable');
-            assert.equal(colName, 'col2');
+            assert.equal(propName, 'col2');
             assert.equal(realType, 'text');
             assert.equal(schemaType, 'int');
 

--- a/test/cassandra/src/CassandraStorage.js
+++ b/test/cassandra/src/CassandraStorage.js
@@ -454,6 +454,59 @@ describe('Cassandra Storage Provider', () => {
             done();
         });
     });
+
+    it('Should drop tables which defined in schema with __dropIfExists__ as true', () => {
+        const mockCassandraClient = new MockCassandraClient();
+        const execSpy = mockCassandraClient.execute;
+        const cassandra = new CassandraStorage(mockCassandraClient);
+        const schemas = {
+            test: {
+                id: 'int',
+                __primaryKey__: [ 'id' ]
+            },
+
+            dropThis: {
+                id: 'int',
+                __primaryKey__: [ 'id' ],
+                __dropIfExists__: true
+            },
+
+            shouldBeDropped: {
+                id: 'int',
+                __primaryKey__: [ 'id' ],
+                __dropIfExists__: true
+            }
+        };
+
+        cassandra.dropTableSchemas(schemas);
+
+        assert.equal(execSpy.callCount, 2);
+    });
+
+    it('Should drop types which defined in schema with __dropIfExists__ as true', () => {
+        const mockCassandraClient = new MockCassandraClient();
+        const execSpy = mockCassandraClient.execute;
+        const cassandra = new CassandraStorage(mockCassandraClient);
+        const schemas = {
+            test: {
+                id: 'int'
+            },
+
+            dropThis: {
+                id: 'int',
+                __dropIfExists__: true
+            },
+
+            shouldBeDropped: {
+                id: 'int',
+                __dropIfExists__: true
+            }
+        };
+
+        cassandra.dropTypeSchemas(schemas);
+
+        assert.equal(execSpy.callCount, 2);
+    });
 });
 
 function asyncAssertion(callback) {

--- a/test/plugin/CassandraPluginService.js
+++ b/test/plugin/CassandraPluginService.js
@@ -22,6 +22,15 @@ describe('Plugin', () => {
         cassandra.insertCommandUpdate = sinon.stub().returns(Promise.resolve({}));
         cassandra.insertNotification = sinon.stub().returns(Promise.resolve({}));
         cassandra.checkSchemasExistence = sinon.stub().returns(cassandra).callsFake(cb => cb(true));
+        cassandra.compareTableSchemas = sinon.stub().returns({
+            on(event, handler) {
+                if (event === 'done') {
+                    handler();
+                }
+
+                return this;
+            }
+        });
 
         sinon.stub(cassandraStorage, 'connect').returns(Promise.resolve(cassandra));
 
@@ -82,10 +91,14 @@ describe('Plugin', () => {
         }).build();
 
         const plugin = new CassandraPluginService();
+        sinon.stub(plugin, 'initCassandra').returns(Promise.resolve(cassandra));
+
         plugin.afterStart();
 
         asyncAssertion(() => {
             plugin.handleMessage(msg);
+
+            plugin.initCassandra.restore();
 
             assert(cassandra.insertCommand.calledOnce);
             done();
@@ -104,14 +117,18 @@ describe('Plugin', () => {
         conf.CUSTOM.COMMAND_UPDATES_STORING = true;
 
         const plugin = new CassandraPluginService();
+        sinon.stub(plugin, 'initCassandra').returns(Promise.resolve(cassandra));
+
         plugin.afterStart();
 
         asyncAssertion(() => {
             plugin.handleMessage(msg);
 
+            plugin.initCassandra.restore();
+            conf.CUSTOM.COMMAND_UPDATES_STORING = commandsUpdatesStoring;
+
             assert(cassandra.insertCommandUpdate.calledOnce);
 
-            conf.CUSTOM.COMMAND_UPDATES_STORING = commandsUpdatesStoring;
             done();
         });
     });
@@ -128,14 +145,18 @@ describe('Plugin', () => {
         conf.CUSTOM.COMMAND_UPDATES_STORING = false;
 
         const plugin = new CassandraPluginService();
+        sinon.stub(plugin, 'initCassandra').returns(Promise.resolve(cassandra));
+
         plugin.afterStart();
 
         asyncAssertion(() => {
             plugin.handleMessage(msg);
 
+            plugin.initCassandra.restore();
+            conf.CUSTOM.COMMAND_UPDATES_STORING = commandsUpdatesStoring;
+
             assert(cassandra.updateCommand.calledOnce);
 
-            conf.CUSTOM.COMMAND_UPDATES_STORING = commandsUpdatesStoring;
             done();
         });
     });
@@ -147,10 +168,14 @@ describe('Plugin', () => {
         }).build();
 
         const plugin = new CassandraPluginService();
+        sinon.stub(plugin, 'initCassandra').returns(Promise.resolve(cassandra));
+
         plugin.afterStart();
 
         asyncAssertion(() => {
             plugin.handleMessage(msg);
+
+            plugin.initCassandra.restore();
 
             assert(cassandra.insertNotification.calledOnce);
             done();

--- a/test/plugin/CassandraPluginService.js
+++ b/test/plugin/CassandraPluginService.js
@@ -22,7 +22,8 @@ describe('Plugin', () => {
         cassandra.insertCommandUpdate = sinon.stub().returns(Promise.resolve({}));
         cassandra.insertNotification = sinon.stub().returns(Promise.resolve({}));
         cassandra.checkSchemasExistence = sinon.stub().returns(cassandra).callsFake(cb => cb(true));
-        cassandra.compareTableSchemas = sinon.stub().returns({
+
+        const notifier = {
             on(event, handler) {
                 if (event === 'done') {
                     handler();
@@ -30,7 +31,9 @@ describe('Plugin', () => {
 
                 return this;
             }
-        });
+        };
+        cassandra.compareTableSchemas = sinon.stub().returns(notifier);
+        cassandra.compareUDTSchemas = sinon.stub().returns(notifier);
 
         sinon.stub(cassandraStorage, 'connect').returns(Promise.resolve(cassandra));
 

--- a/test/plugin/cassandraSchema/index.js
+++ b/test/plugin/cassandraSchema/index.js
@@ -14,7 +14,9 @@ describe('Cassandra schemas creation', () => {
         cassandra.createTableSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.createUDTSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.setTableSchemas = sinon.stub().returns(cassandra);
-        cassandra.compareTableSchemas = sinon.stub().returns({
+        cassandra.setUDTSchemas = sinon.stub().returns(cassandra);
+
+        const notifier = {
             on(event, handler) {
                 if (event === 'done') {
                     handler();
@@ -22,7 +24,9 @@ describe('Cassandra schemas creation', () => {
 
                 return this;
             }
-        });
+        };
+        cassandra.compareTableSchemas = sinon.stub().returns(notifier);
+        cassandra.compareUDTSchemas = sinon.stub().returns(notifier);
 
         sandbox.stub(cassandraStorage, 'connect').returns(Promise.resolve(cassandra));
         sandbox.stub(process, 'exit');

--- a/test/plugin/cassandraSchema/index.js
+++ b/test/plugin/cassandraSchema/index.js
@@ -14,7 +14,9 @@ describe('Cassandra schemas creation', () => {
         cassandra.createTableSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.createUDTSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.setTableSchemas = sinon.stub().returns(cassandra);
-        cassandra.setUDTSchemas = sinon.stub().returns(cassandra);
+        cassandra.setUDTSchemas = sinon.stub().returns(cassandra)
+        cassandra.dropTypeSchemas = sinon.stub().returns(Promise.resolve({}));
+        cassandra.dropTableSchemas = sinon.stub().returns(Promise.resolve({}));
 
         const notifier = {
             on(event, handler) {

--- a/test/plugin/cassandraSchema/index.js
+++ b/test/plugin/cassandraSchema/index.js
@@ -7,19 +7,22 @@ describe('Cassandra schemas creation', () => {
     const sandbox = sinon.createSandbox();
     let cassandra;
 
-    before(() => {
-        sinon.stub(console, 'error');
-    });
-
-    after(() => {
-        console.error.restore();
-    });
 
     beforeEach(() => {
-        cassandra = {
-            createTableSchemas: sinon.stub().returns(Promise.resolve({})),
-            createUDTSchemas: sinon.stub().returns(Promise.resolve({}))
-        };
+        cassandra = {};
+
+        cassandra.createTableSchemas = sinon.stub().returns(Promise.resolve({}));
+        cassandra.createUDTSchemas = sinon.stub().returns(Promise.resolve({}));
+        cassandra.setTableSchemas = sinon.stub().returns(cassandra);
+        cassandra.compareTableSchemas = sinon.stub().returns({
+            on(event, handler) {
+                if (event === 'done') {
+                    handler();
+                }
+
+                return this;
+            }
+        });
 
         sandbox.stub(cassandraStorage, 'connect').returns(Promise.resolve(cassandra));
         sandbox.stub(process, 'exit');


### PR DESCRIPTION
- Notify user when table or UDT already exists
- Fail app if table or UDT has different schemas in JSON and in real Cassandra instance
- Fail app if column of table or field of UDT has different type
- Introduce Metadata class
- Refactoring