### PR TITLE
DEV-388:ADD: Ability to drop tables and types before schema creation

### DIFF
--- a/cassandra/lib/BaseSchemaBuilder.js
+++ b/cassandra/lib/BaseSchemaBuilder.js
@@ -2,13 +2,18 @@ const Utils = require('./Utils');
 
 class BaseSchemaBuilder {
     static get CREATE_QUERY_TYPE() { return 0; }
+    static get DROP_QUERY_TYPE() { return 1; }
+
+    static get TYPE_STRUCTURE() { return 'TYPE'; }
+    static get TABLE_STRUCTURE() { return 'TABLE'; }
 
     constructor() {
-        this._query = '';
+        this._queryString = '';
         this._queryType = null;
         this._name = '';
         this._definition = '';
-        this._ifNotExists = '';
+        this._ifCondition = '';
+        this._structureType = '';
     }
 
     /**
@@ -25,7 +30,7 @@ class BaseSchemaBuilder {
      * @returns {string}
      */
     build() {
-        return `${this._query} ${this._ifNotExists}${this._name}${this._definition}`;
+        return `${this._queryString} ${this._ifCondition}${this._name}${this._definition}`;
     }
 
     /**
@@ -43,24 +48,62 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifNotExists() {
-        if(this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
-            // @TODO Remove this variable, use append to this._query and appropriate flag for IF NOT EXISTS
-            this._ifNotExists = 'IF NOT EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
+            // @TODO Remove this variable, use append to this._queryString and appropriate flag for IF NOT EXISTS
+            this._ifCondition = 'IF NOT EXISTS ';
         }
 
         return this;
     }
 
     /**
-     * Specifies type of query
-     * @param {string} structureType
-     * @param [name = '']
+     * Drop structure only if it exists
      * @returns {BaseSchemaBuilder}
      */
-    _create(structureType, name = '') {
-        this._queryType = BaseSchemaBuilder.CREATE_QUERY_TYPE;        
-        this._query = `CREATE ${structureType}`;
-        
+    ifExists() {
+        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE) {
+            this._ifCondition = 'IF EXISTS ';
+        }
+
+        return this;
+    }
+
+    /**
+     * Specifies create type of query
+     * @param [name = '']
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _create(name = '') {
+        return this._query(BaseSchemaBuilder.CREATE_QUERY_TYPE, name);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [name = '']
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _drop(name = '') {
+        return this._query(BaseSchemaBuilder.DROP_QUERY_TYPE, name);
+    }
+
+    /**
+     * Specify query with given type
+     * @param type
+     * @param name
+     * @returns {BaseSchemaBuilder}
+     * @private
+     */
+    _query(type, name = '') {
+        const queryTypes = {
+            [BaseSchemaBuilder.CREATE_QUERY_TYPE]: 'CREATE',
+            [BaseSchemaBuilder.DROP_QUERY_TYPE]: 'DROP'
+        };
+
+        this._queryType = type;
+        this._queryString = `${queryTypes[type]} ${this._structureType}`;
+
         return Utils.isEmpty(name) ? this : this.withName(name);
     }
 }

--- a/cassandra/lib/BaseSchemaBuilder.js
+++ b/cassandra/lib/BaseSchemaBuilder.js
@@ -1,18 +1,12 @@
 const Utils = require('./Utils');
 
 class BaseSchemaBuilder {
-    static get CREATE_QUERY_TYPE() { return 0; }
-    static get DROP_QUERY_TYPE() { return 1; }
-
-    static get TYPE_STRUCTURE() { return 'TYPE'; }
-    static get TABLE_STRUCTURE() { return 'TABLE'; }
-
     constructor() {
         this._queryString = '';
         this._queryType = null;
         this._name = '';
         this._definition = '';
-        this._ifCondition = '';
+        this._ifConditionExists = false;
         this._structureType = '';
     }
 
@@ -30,7 +24,7 @@ class BaseSchemaBuilder {
      * @returns {string}
      */
     build() {
-        return `${this._queryString} ${this._ifCondition}${this._name}${this._definition}`;
+        return `${this._queryString} ${this._name}${this._definition}`;
     }
 
     /**
@@ -48,9 +42,9 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifNotExists() {
-        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE) {
-            // @TODO Remove this variable, use append to this._queryString and appropriate flag for IF NOT EXISTS
-            this._ifCondition = 'IF NOT EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.CREATE_QUERY_TYPE && !this._ifConditionExists) {
+            this._ifConditionExists = true;
+            this._queryString += ' IF NOT EXISTS';
         }
 
         return this;
@@ -61,8 +55,9 @@ class BaseSchemaBuilder {
      * @returns {BaseSchemaBuilder}
      */
     ifExists() {
-        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE) {
-            this._ifCondition = 'IF EXISTS ';
+        if (this._queryType === BaseSchemaBuilder.DROP_QUERY_TYPE && !this._ifConditionExists) {
+            this._ifConditionExists = true;
+            this._queryString += ' IF EXISTS';
         }
 
         return this;
@@ -106,6 +101,12 @@ class BaseSchemaBuilder {
 
         return Utils.isEmpty(name) ? this : this.withName(name);
     }
+
+    static get CREATE_QUERY_TYPE() { return 0; }
+    static get DROP_QUERY_TYPE() { return 1; }
+
+    static get TYPE_STRUCTURE() { return 'TYPE'; }
+    static get TABLE_STRUCTURE() { return 'TABLE'; }
 }
 
 module.exports = BaseSchemaBuilder;

--- a/cassandra/lib/CQLBuilder.js
+++ b/cassandra/lib/CQLBuilder.js
@@ -27,6 +27,23 @@ class CQLBuilder {
     }
 
     /**
+     * Creates query based on given type
+     * @param type CQLBuilder.INSERT_QUERY or CQLBuilder.UPDATE_QUERY
+     * @returns {QueryBuilder}
+     */
+    static query(type) {
+        const queryBuilder = new QueryBuilder();
+
+        if (type === CQLBuilder.INSERT_QUERY) {
+            queryBuilder.insertInto();
+        } else if (type === CQLBuilder.UPDATE_QUERY) {
+            queryBuilder.update();
+        }
+
+        return queryBuilder;
+    }
+
+    /**
      * Creates table creation type of query
      * @param tableName
      * @returns {TableSchemaBuilder}
@@ -44,16 +61,12 @@ class CQLBuilder {
         return new UDTSchemaBuilder().createType(typeName);
     }
 
-    static query(type) {
-        const queryBuilder = new QueryBuilder();
+    static dropTable(tableName = '') {
+        return new TableSchemaBuilder().dropTable(tableName);
+    }
 
-        if (type === CQLBuilder.INSERT_QUERY) {
-            queryBuilder.insertInto();
-        } else if (type === CQLBuilder.UPDATE_QUERY) {
-            queryBuilder.update();
-        }
-
-        return queryBuilder;
+    static dropType(typeName = '') {
+        return new UDTSchemaBuilder().dropType(typeName);
     }
 }
 

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -263,6 +263,10 @@ class JSONSchema {
         return cols;
     }
 
+    /**
+     * Returns true if schema contains __dropIfExists__ set in true
+     * @returns {boolean}
+     */
     shouldBeDropped() {
         const dropIfExists = this._schema[JSONSchema.DROP_IF_EXISTS];
         return !!Utils.booleanOrDefault(dropIfExists);

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -7,6 +7,7 @@ class JSONSchema {
     static get CLUSTERED_KEY() { return '__clusteredKey__'; }
     static get ORDER() { return '__order__'; }
     static get OPTIONS() { return '__options__'; }
+    static get DROP_IF_EXISTS() { return '__dropIfExists__'; }
 
     constructor(schema = {}) {
         this._schema = Utils.copy(schema);
@@ -262,6 +263,11 @@ class JSONSchema {
         return cols;
     }
 
+    shouldBeDropped() {
+        const dropIfExists = this._schema[JSONSchema.DROP_IF_EXISTS];
+        return !!Utils.booleanOrDefault(dropIfExists);
+    }
+
     /**
      * Returns true if property name is not specified as reserved
      * @param propName
@@ -272,7 +278,8 @@ class JSONSchema {
             JSONSchema.PRIMARY_KEY,
             JSONSchema.CLUSTERED_KEY,
             JSONSchema.ORDER,
-            JSONSchema.OPTIONS
+            JSONSchema.OPTIONS,
+            JSONSchema.DROP_IF_EXISTS
         ];
 
         return !reservedProps.includes(propName);

--- a/cassandra/lib/TableSchemaBuilder.js
+++ b/cassandra/lib/TableSchemaBuilder.js
@@ -2,13 +2,27 @@ const JSONSchema = require('./JSONSchema');
 const BaseSchemaBuilder = require('./BaseSchemaBuilder');
 
 class TableSchemaBuilder extends BaseSchemaBuilder {
+    constructor() {
+        super();
+        this._structureType = TableSchemaBuilder.TABLE_STRUCTURE;
+    }
+
     /**
-     * Specifies type of query
+     * Specifies create type of query
      * @param [tableName = '']
      * @returns {TableSchemaBuilder}
      */
     createTable(tableName = '') {
-        return this._create('TABLE', tableName);
+        return this._create(tableName);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [tableName = '']
+     * @returns {TableSchemaBuilder}
+     */
+    dropTable(tableName) {
+        return this._drop(tableName);
     }
 
     /**

--- a/cassandra/lib/UDTSchemaBuilder.js
+++ b/cassandra/lib/UDTSchemaBuilder.js
@@ -2,13 +2,27 @@ const JSONSchema = require('./JSONSchema');
 const BaseSchemaBuilder = require('./BaseSchemaBuilder');
 
 class UDTSchemaBuilder extends BaseSchemaBuilder {
+    constructor() {
+        super();
+        this._structureType = UDTSchemaBuilder.TYPE_STRUCTURE;
+    }
+
     /**
-     * Specifies type of query
+     * Specifies create type of query
      * @param [typeName = '']
      * @returns {UDTSchemaBuilder}
      */
     createType(typeName = '') {
-        return this._create('TYPE', typeName);
+        return this._create(typeName);
+    }
+
+    /**
+     * Specifies drop type of query
+     * @param [typeName = '']
+     * @returns {UDTSchemaBuilder}
+     */
+    dropType(typeName) {
+        return this._drop(typeName);
     }
 
     /**

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -14,6 +14,10 @@ class SchemaCreator {
             .then(() => this._client.createTableSchemas(tables));
     }
 
+    dropBeforeCreate({ udt, tables }) {
+        return this._client.dropTableSchemas(tables).then(() => this._client.dropTypeSchemas(udt));
+    }
+
     _resolveSchemaComparison(tableComparisonNotifier, udtComparisonNotifier) {
         const tableComparison = new Promise((resolve, reject) => {
             let ok = true;

--- a/plugin/cassandraSchema/index.js
+++ b/plugin/cassandraSchema/index.js
@@ -16,12 +16,16 @@ createSchema().then(() => {
 });
 
 function createSchema() {
+    const schemas = {
+        udt: cassandraUDTs,
+        tables: cassandraTables.tables
+    };
+    let schemaCreator;
+
     return CassandraStorage.connect(cassandraConfig).then(cassandra => {
-        return new SchemaCreator(cassandra).create({
-            udt: cassandraUDTs,
-            tables: cassandraTables.tables
-        });
-    });
+        schemaCreator = new SchemaCreator(cassandra);
+        return schemaCreator.dropBeforeCreate(schemas);
+    }).then(() => schemaCreator.create(schemas));
 }
 
 function exitIfInvalid(schemas) {

--- a/test/cassandra/lib/JSONSchema.js
+++ b/test/cassandra/lib/JSONSchema.js
@@ -250,4 +250,13 @@ describe('JSON Schema', () => {
 
         assert.equal(mismatches.length, 0);
     });
+
+    it('Should return false for shouldBeDropped() if __dropIfExists__ is absent in schema', () => {
+        const schema = new JSONSchema({
+            id: 'int',
+            __primaryKey__: [ 'id' ]
+        });
+
+        assert.strictEqual(schema.shouldBeDropped(), false);
+    });
 });

--- a/test/cassandra/lib/TableSchemaBuilder.js
+++ b/test/cassandra/lib/TableSchemaBuilder.js
@@ -128,4 +128,14 @@ describe('Table Schema Builder', () => {
         const query = builder.build();
         assert.equal(query, expectedQuery);
     });
+
+    it('Should build DROP TABLE query', () => {
+        const query = new TableSchemaBuilder().dropTable('my_table').build();
+        assert.equal(query, 'DROP TABLE my_table');
+    });
+
+    it('Should build DROP TABLE query with IF EXISTS', () => {
+        const query = new TableSchemaBuilder().dropTable('my_table').ifExists().build();
+        assert.equal(query, 'DROP TABLE IF EXISTS my_table');
+    });
 });

--- a/test/cassandra/lib/UDTSchemaBuilder.js
+++ b/test/cassandra/lib/UDTSchemaBuilder.js
@@ -26,4 +26,14 @@ describe('User Defined Type Builder', () => {
 
         assert.equal(query, 'CREATE TYPE IF NOT EXISTS test(prop1 int)');
     });
+
+    it('Should build DROP TYPE query', () => {
+        const query = new UDTSchemaBuilder().dropType('test').build();
+        assert.equal(query, 'DROP TYPE test');
+    });
+
+    it('Should build DROP TABLE query with IF EXISTS', () => {
+        const query = new UDTSchemaBuilder().dropType('test').ifExists().build();
+        assert.equal(query, 'DROP TYPE IF EXISTS test');
+    });
 });

--- a/test/cassandra/src/CassandraStorage.js
+++ b/test/cassandra/src/CassandraStorage.js
@@ -454,6 +454,59 @@ describe('Cassandra Storage Provider', () => {
             done();
         });
     });
+
+    it('Should drop tables which defined in schema with __dropIfExists__ as true', () => {
+        const mockCassandraClient = new MockCassandraClient();
+        const execSpy = mockCassandraClient.execute;
+        const cassandra = new CassandraStorage(mockCassandraClient);
+        const schemas = {
+            test: {
+                id: 'int',
+                __primaryKey__: [ 'id' ]
+            },
+
+            dropThis: {
+                id: 'int',
+                __primaryKey__: [ 'id' ],
+                __dropIfExists__: true
+            },
+
+            shouldBeDropped: {
+                id: 'int',
+                __primaryKey__: [ 'id' ],
+                __dropIfExists__: true
+            }
+        };
+
+        cassandra.dropTableSchemas(schemas);
+
+        assert.equal(execSpy.callCount, 2);
+    });
+
+    it('Should drop types which defined in schema with __dropIfExists__ as true', () => {
+        const mockCassandraClient = new MockCassandraClient();
+        const execSpy = mockCassandraClient.execute;
+        const cassandra = new CassandraStorage(mockCassandraClient);
+        const schemas = {
+            test: {
+                id: 'int'
+            },
+
+            dropThis: {
+                id: 'int',
+                __dropIfExists__: true
+            },
+
+            shouldBeDropped: {
+                id: 'int',
+                __dropIfExists__: true
+            }
+        };
+
+        cassandra.dropTypeSchemas(schemas);
+
+        assert.equal(execSpy.callCount, 2);
+    });
 });
 
 function asyncAssertion(callback) {

--- a/test/plugin/cassandraSchema/index.js
+++ b/test/plugin/cassandraSchema/index.js
@@ -14,7 +14,9 @@ describe('Cassandra schemas creation', () => {
         cassandra.createTableSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.createUDTSchemas = sinon.stub().returns(Promise.resolve({}));
         cassandra.setTableSchemas = sinon.stub().returns(cassandra);
-        cassandra.setUDTSchemas = sinon.stub().returns(cassandra);
+        cassandra.setUDTSchemas = sinon.stub().returns(cassandra)
+        cassandra.dropTypeSchemas = sinon.stub().returns(Promise.resolve({}));
+        cassandra.dropTableSchemas = sinon.stub().returns(Promise.resolve({}));
 
         const notifier = {
             on(event, handler) {


### PR DESCRIPTION
- Support of `__dropIfExists__` flag in table and type schemas, if this flag is true then drop table/type before schema creation