### PR TITLE
DEV-388:ADD: Primary and clustering key comparisons with existing table schema

### DIFF
--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -218,6 +218,10 @@ class JSONSchema {
         return Metadata.create(metadataDescriptor).isSameMembersSchema(this);
     }
 
+    comparePrimaryKeyWithMetadata(metadataDescriptor) {
+        return Metadata.create(metadataDescriptor).isSamePrimaryKey(this);
+    }
+
     /**
      * Returns array of property types mismatches in schema with metadata
      * @param metadataDescriptor cassandra-driver metadata object
@@ -261,6 +265,10 @@ class JSONSchema {
         }
 
         return cols;
+    }
+
+    getPrimaryKey() {
+        return JSONSchema.invalidPrimaryKey(this._schema) ? [] : [].concat(this._schema[JSONSchema.PRIMARY_KEY]);
     }
 
     /**

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -218,10 +218,20 @@ class JSONSchema {
         return Metadata.create(metadataDescriptor).isSameMembersSchema(this);
     }
 
+    /**
+     * Returns true if schema contains same primary key as metadata
+     * @param metadataDescriptor
+     * @returns {boolean|*}
+     */
     comparePrimaryKeyWithMetadata(metadataDescriptor) {
         return Metadata.create(metadataDescriptor).isSamePrimaryKey(this);
     }
 
+    /**
+     * Returns true if schema contains same clustering key as metadata
+     * @param metadataDescriptor
+     * @returns {boolean|*}
+     */
     compareClusteringKeyWithMetadata(metadataDescriptor) {
         return Metadata.create(metadataDescriptor).isSameClusteringKey(this);
     }

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -4,7 +4,7 @@ const Metadata = require('./metadata');
 
 class JSONSchema {
     static get PRIMARY_KEY() { return '__primaryKey__'; }
-    static get CLUSTERED_KEY() { return '__clusteredKey__'; }
+    static get CLUSTERING_KEY() { return '__clusteringKey__'; }
     static get ORDER() { return '__order__'; }
     static get OPTIONS() { return '__options__'; }
     static get DROP_IF_EXISTS() { return '__dropIfExists__'; }
@@ -44,7 +44,7 @@ class JSONSchema {
     }
 
     /**
-     * Constructs primary and clustered key definition
+     * Constructs primary and clustering key definition
      * @returns {string}
      */
     buildKeys() {
@@ -55,9 +55,9 @@ class JSONSchema {
         const primaryKeyColumns = this._schema[JSONSchema.PRIMARY_KEY].join(',');
         let primaryKeyDefinition = `(${primaryKeyColumns})`;
 
-        if (JSONSchema.validClusteredKey(this._schema)) {
-            const clusteredKeyColumns = this._schema[JSONSchema.CLUSTERED_KEY].join(',');
-            primaryKeyDefinition += `,${clusteredKeyColumns}`;
+        if (JSONSchema.validClusteringKey(this._schema)) {
+            const clusteringKeyColumns = this._schema[JSONSchema.CLUSTERING_KEY].join(',');
+            primaryKeyDefinition += `,${clusteringKeyColumns}`;
         }
 
 
@@ -182,9 +182,9 @@ class JSONSchema {
 
     isKey(prop) {
         const primaryKeys = this._schema[JSONSchema.PRIMARY_KEY] || [];
-        const clusteredKeys = this._schema[JSONSchema.CLUSTERED_KEY] || [];
+        const clusteringKeys = this._schema[JSONSchema.CLUSTERING_KEY] || [];
 
-        return primaryKeys.includes(prop) || clusteredKeys.includes(prop);
+        return primaryKeys.includes(prop) || clusteringKeys.includes(prop);
     }
 
     /**
@@ -288,7 +288,7 @@ class JSONSchema {
     static isNotReservedProperty(propName) {
         const reservedProps = [
             JSONSchema.PRIMARY_KEY,
-            JSONSchema.CLUSTERED_KEY,
+            JSONSchema.CLUSTERING_KEY,
             JSONSchema.ORDER,
             JSONSchema.OPTIONS,
             JSONSchema.DROP_IF_EXISTS
@@ -307,12 +307,12 @@ class JSONSchema {
     }
 
     /**
-     * Returns true if clustered key of schema is valid
+     * Returns true if clustering key of schema is valid
      * @param schema
      * @returns {boolean}
      */
-    static validClusteredKey(schema) {
-        return schema.hasOwnProperty(JSONSchema.CLUSTERED_KEY) && schema[JSONSchema.CLUSTERED_KEY].length;
+    static validClusteringKey(schema) {
+        return schema.hasOwnProperty(JSONSchema.CLUSTERING_KEY) && schema[JSONSchema.CLUSTERING_KEY].length;
     }
 }
 

--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -222,6 +222,10 @@ class JSONSchema {
         return Metadata.create(metadataDescriptor).isSamePrimaryKey(this);
     }
 
+    compareClusteringKeyWithMetadata(metadataDescriptor) {
+        return Metadata.create(metadataDescriptor).isSameClusteringKey(this);
+    }
+
     /**
      * Returns array of property types mismatches in schema with metadata
      * @param metadataDescriptor cassandra-driver metadata object
@@ -267,8 +271,20 @@ class JSONSchema {
         return cols;
     }
 
+    /**
+     * Returns primary key columns if primary key is valid
+     * @returns {Array}
+     */
     getPrimaryKey() {
-        return JSONSchema.invalidPrimaryKey(this._schema) ? [] : [].concat(this._schema[JSONSchema.PRIMARY_KEY]);
+        return JSONSchema.validPrimaryKey(this._schema) ? [].concat(this._schema[JSONSchema.PRIMARY_KEY]) : [];
+    }
+
+    /**
+     * Returns clustering key columns if clustering key is valid
+     * @returns {Array}
+     */
+    getClusteringKey() {
+        return JSONSchema.validClusteringKey(this._schema) ? [].concat(this._schema[JSONSchema.CLUSTERING_KEY]) : [];
     }
 
     /**
@@ -303,7 +319,16 @@ class JSONSchema {
      * @returns {boolean}
      */
     static invalidPrimaryKey(schema) {
-        return !schema.hasOwnProperty(JSONSchema.PRIMARY_KEY) || !schema[JSONSchema.PRIMARY_KEY].length;
+        return !JSONSchema.validPrimaryKey(schema);
+    }
+
+    /**
+     * Returns true if primary key of schema is valid
+     * @param schema
+     * @returns {boolean}
+     */
+    static validPrimaryKey(schema) {
+        return Utils.isNotEmpty(schema[JSONSchema.PRIMARY_KEY]);
     }
 
     /**
@@ -312,7 +337,7 @@ class JSONSchema {
      * @returns {boolean}
      */
     static validClusteringKey(schema) {
-        return schema.hasOwnProperty(JSONSchema.CLUSTERING_KEY) && schema[JSONSchema.CLUSTERING_KEY].length;
+        return Utils.isNotEmpty(schema[JSONSchema.CLUSTERING_KEY]);
     }
 }
 

--- a/cassandra/lib/metadata/Metadata.js
+++ b/cassandra/lib/metadata/Metadata.js
@@ -40,6 +40,15 @@ class Metadata {
     }
 
     /**
+     * Returns true if schema has same primary key as metadata
+     * @param jsonSchema
+     * @returns {boolean}
+     */
+    isSamePrimaryKey(jsonSchema) {
+        return true;
+    }
+
+    /**
      * Returns true if JSON schema is the same as metadata of real schema (contains same members)
      * @param {JSONSchema} jsonSchema
      * @param {Array<string>} metadataProps Array of member names of structure (table or UDT)

--- a/cassandra/lib/metadata/Metadata.js
+++ b/cassandra/lib/metadata/Metadata.js
@@ -49,6 +49,15 @@ class Metadata {
     }
 
     /**
+     * Returns true if schema has same clustering key as metadata
+     * @param jsonSchema
+     * @returns {boolean}
+     */
+    isSameClusteringKey(jsonSchema) {
+        return true;
+    }
+
+    /**
      * Returns true if JSON schema is the same as metadata of real schema (contains same members)
      * @param {JSONSchema} jsonSchema
      * @param {Array<string>} metadataProps Array of member names of structure (table or UDT)

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -14,6 +14,17 @@ class TableMetadata extends Metadata {
     _getTypeDescription(colName) {
         return this._md.columnsByName[colName].type;
     }
+
+    isSamePrimaryKey(jsonSchema) {
+        const jsonSchemaPrimaryKey = jsonSchema.getPrimaryKey().map(pk => pk.toLowerCase());
+        const metadataPrimaryKey = (this._md.partitionKeys || []).map(pk => pk.name);
+
+        if (jsonSchemaPrimaryKey.length !== metadataPrimaryKey.length) {
+            return false;
+        }
+
+        return jsonSchemaPrimaryKey.every(pk => metadataPrimaryKey.includes(pk));
+    }
 }
 
 module.exports = TableMetadata;

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -25,6 +25,17 @@ class TableMetadata extends Metadata {
 
         return jsonSchemaPrimaryKey.every(pk => metadataPrimaryKey.includes(pk));
     }
+
+    isSameClusteringKey(jsonSchema) {
+        const jsonSchemaClusteringKey = jsonSchema.getClusteringKey().map(ck => ck.toLowerCase());
+        const metadataClusteringKey = (this._md.clusteringKeys || []).map(ck => ck.name);
+
+        if (jsonSchemaClusteringKey.length !== metadataClusteringKey.length) {
+            return false;
+        }
+
+        return jsonSchemaClusteringKey.every(ck => metadataClusteringKey.includes(ck));
+    }
 }
 
 module.exports = TableMetadata;

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -16,25 +16,33 @@ class TableMetadata extends Metadata {
     }
 
     isSamePrimaryKey(jsonSchema) {
-        const jsonSchemaPrimaryKey = jsonSchema.getPrimaryKey().map(pk => pk.toLowerCase());
-        const metadataPrimaryKey = (this._md.partitionKeys || []).map(pk => pk.name);
-
-        if (jsonSchemaPrimaryKey.length !== metadataPrimaryKey.length) {
-            return false;
-        }
-
-        return jsonSchemaPrimaryKey.every(pk => metadataPrimaryKey.includes(pk));
+        return this._isSameKey('primary', jsonSchema);
     }
 
     isSameClusteringKey(jsonSchema) {
-        const jsonSchemaClusteringKey = jsonSchema.getClusteringKey().map(ck => ck.toLowerCase());
-        const metadataClusteringKey = (this._md.clusteringKeys || []).map(ck => ck.name);
+        return this._isSameKey('clustering', jsonSchema);
+    }
 
-        if (jsonSchemaClusteringKey.length !== metadataClusteringKey.length) {
+    _isSameKey(keyType, jsonSchema) {
+        let jsonSchemaKey;
+        let metadataKey;
+
+        if (keyType === 'primary') {
+            jsonSchemaKey = jsonSchema.getPrimaryKey();
+            metadataKey = this._md.partitionKeys;
+        } else {
+            jsonSchemaKey = jsonSchema.getClusteringKey();
+            metadataKey = this._md.clusteringKeys;
+        }
+
+        jsonSchemaKey = jsonSchemaKey.map(k => k.toLowerCase());
+        metadataKey = (metadataKey || []).map(k => k.name);
+
+        if (jsonSchemaKey.length !== metadataKey.length) {
             return false;
         }
 
-        return jsonSchemaClusteringKey.every(ck => metadataClusteringKey.includes(ck));
+        return jsonSchemaKey.every(k => metadataKey.includes(k));
     }
 }
 

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -270,6 +270,10 @@ class CassandraStorage {
                     const mismatchDetails = [ name, mismatch.propName, mismatch.realType, mismatch.schemaType ];
                     notifier.notifyTypesMismatch(...mismatchDetails);
                 });
+
+                if (!schema.comparePrimaryKeyWithMetadata(md)) {
+                    notifier.notifyPrimaryKeyMismatch(name);
+                }
             });
         });
 

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -274,6 +274,10 @@ class CassandraStorage {
                 if (!schema.comparePrimaryKeyWithMetadata(md)) {
                     notifier.notifyPrimaryKeyMismatch(name);
                 }
+
+                if (!schema.compareClusteringKeyWithMetadata(md)) {
+                    notifier.notifyClusteringKeyMismatch(name);
+                }
             });
         });
 

--- a/cassandra/src/SchemaComparisonNotifier.js
+++ b/cassandra/src/SchemaComparisonNotifier.js
@@ -3,7 +3,8 @@ const EventEmitter = require('events');
 class SchemaComparisonNotifier extends EventEmitter {
     constructor(events) {
         super();
-        this._events = events;
+        this._events = { ...events };
+        this._events.primaryKeyMismatch = 'primaryKeyMismatch';
     }
 
     notifyExistence(name) {
@@ -16,6 +17,10 @@ class SchemaComparisonNotifier extends EventEmitter {
 
     notifyTypesMismatch(...mismatchDetails) {
         return this.emit(this._events.typesMismatch, ...mismatchDetails);
+    }
+
+    notifyPrimaryKeyMismatch(name) {
+        return this.emit(this._events.primaryKeyMismatch, name);
     }
 }
 

--- a/cassandra/src/SchemaComparisonNotifier.js
+++ b/cassandra/src/SchemaComparisonNotifier.js
@@ -5,6 +5,7 @@ class SchemaComparisonNotifier extends EventEmitter {
         super();
         this._notificationEvents = { ...events };
         this._notificationEvents.primaryKeyMismatch = 'primaryKeyMismatch';
+        this._notificationEvents.clusteringKeyMismatch = 'clusteringKeyMismatch';
     }
 
     notifyExistence(name) {
@@ -21,6 +22,10 @@ class SchemaComparisonNotifier extends EventEmitter {
 
     notifyPrimaryKeyMismatch(name) {
         return this.emit(this._notificationEvents.primaryKeyMismatch, name);
+    }
+
+    notifyClusteringKeyMismatch(name) {
+        return this.emit(this._notificationEvents.clusteringKeyMismatch, name);
     }
 }
 

--- a/cassandra/src/SchemaComparisonNotifier.js
+++ b/cassandra/src/SchemaComparisonNotifier.js
@@ -3,24 +3,24 @@ const EventEmitter = require('events');
 class SchemaComparisonNotifier extends EventEmitter {
     constructor(events) {
         super();
-        this._events = { ...events };
-        this._events.primaryKeyMismatch = 'primaryKeyMismatch';
+        this._notificationEvents = { ...events };
+        this._notificationEvents.primaryKeyMismatch = 'primaryKeyMismatch';
     }
 
     notifyExistence(name) {
-        return this.emit(this._events.exists, name);
+        return this.emit(this._notificationEvents.exists, name);
     }
 
     notifyStructureMismatch(name) {
-        return this.emit(this._events.structureMismatch, name);
+        return this.emit(this._notificationEvents.structureMismatch, name);
     }
 
     notifyTypesMismatch(...mismatchDetails) {
-        return this.emit(this._events.typesMismatch, ...mismatchDetails);
+        return this.emit(this._notificationEvents.typesMismatch, ...mismatchDetails);
     }
 
     notifyPrimaryKeyMismatch(name) {
-        return this.emit(this._events.primaryKeyMismatch, name);
+        return this.emit(this._notificationEvents.primaryKeyMismatch, name);
     }
 }
 

--- a/cassandraSchemas/cassandra-tables.json
+++ b/cassandraSchemas/cassandra-tables.json
@@ -8,7 +8,7 @@
       "parameters": "frozen<params>",
 
       "__primaryKey__": [ "command", "deviceId" ],
-      "__clusteredKey__": [ "timestamp" ],
+      "__clusteringKey__": [ "timestamp" ],
       "__order__": {
         "timestamp": "DESC"
       },
@@ -46,7 +46,7 @@
       "timestamp": "timestamp",
 
       "__primaryKey__": [ "notification", "deviceId" ],
-      "__clusteredKey__": [ "timestamp" ],
+      "__clusteringKey__": [ "timestamp" ],
       "__order__": {
         "timestamp": "DESC"
       }
@@ -58,7 +58,7 @@
       "timestamp": "timestamp",
 
       "__primaryKey__": [ "command", "deviceId" ],
-      "__clusteredKey__": [ "timestamp" ],
+      "__clusteringKey__": [ "timestamp" ],
       "__order__": {
         "timestamp": "DESC"
       }

--- a/plugin/cassandraInit.js
+++ b/plugin/cassandraInit.js
@@ -70,6 +70,9 @@ function schemaComparison(cassandra) {
         }).on('columnTypesMismatch', (tableName, colName, realType, schemaType) => {
             console.log(`TABLE ${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
             ok = false;
+        }).on('primaryKeyMismatch', tableName => {
+            console.log(`TABLE ${tableName}: Mismatched primary key`);
+            ok = false;
         }).on('done', () => {
             if (ok) {
                 resolve();

--- a/plugin/cassandraInit.js
+++ b/plugin/cassandraInit.js
@@ -73,6 +73,9 @@ function schemaComparison(cassandra) {
         }).on('primaryKeyMismatch', tableName => {
             console.log(`TABLE ${tableName}: Mismatched primary key`);
             ok = false;
+        }).on('clusteringKeyMismatch', tableName => {
+            console.log(`TABLE ${tableName}: Mismatched clustering key`);
+            ok = false;
         }).on('done', () => {
             if (ok) {
                 resolve();

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -30,6 +30,9 @@ class SchemaCreator {
             }).on('columnTypesMismatch', (tableName, colName, realType, schemaType) => {
                 console.log(`TABLE ${tableName}: Mismatched ${colName} type, actual "${realType}", in JSON schema "${schemaType}"`);
                 ok = false;
+            }).on('primaryKeyMismatch', tableName => {
+                console.log(`TABLE ${tableName}: Mismatched primary key`);
+                ok = false;
             }).on('done', () => {
                 if (ok) {
                     resolve();

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -33,6 +33,9 @@ class SchemaCreator {
             }).on('primaryKeyMismatch', tableName => {
                 console.log(`TABLE ${tableName}: Mismatched primary key`);
                 ok = false;
+            }).on('clusteringKeyMismatch', tableName => {
+                console.log(`TABLE ${tableName}: Mismatched clustering key`);
+                ok = false;
             }).on('done', () => {
                 if (ok) {
                     resolve();

--- a/test/cassandra/dataBuilders/TableMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/TableMetadataBuilder.js
@@ -1,9 +1,18 @@
 const DataBuilder = require('smp-data-builder');
 
 class TableMetadataBuilder extends DataBuilder {
+    withClusteringKey(...colNames) {
+        return this.withKey('clustering', ...colNames);
+
+    }
+
     withPrimaryKey(...colNames) {
+        return this.withKey('partition', ...colNames);
+    }
+
+    withKey(keyType, ...colNames) {
         colNames.forEach(col => {
-            this.with('partitionKeys', [ { name: col } ]);
+            this.with(`${keyType}Keys`, [ { name: col } ]);
         });
 
         return this;

--- a/test/cassandra/dataBuilders/TableMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/TableMetadataBuilder.js
@@ -1,6 +1,14 @@
 const DataBuilder = require('smp-data-builder');
 
 class TableMetadataBuilder extends DataBuilder {
+    withPrimaryKey(...colNames) {
+        colNames.forEach(col => {
+            this.with('partitionKeys', [ { name: col } ]);
+        });
+
+        return this;
+    }
+
     withColumnTypeOption(columnName, optName, optVal) {
         const type = this.obj.columnsByName[columnName].type;
 

--- a/test/cassandra/dataBuilders/TablesBuilder.js
+++ b/test/cassandra/dataBuilders/TablesBuilder.js
@@ -8,7 +8,7 @@ class TablesBuilder extends DataBuilder {
                 col2: 'text',
                 col3: 'varchar',
                 __primaryKey__: [ 'col1' ],
-                __clusteredKey__: [ 'col2' ]
+                __clusteringKey__: [ 'col2' ]
             });
         });
 

--- a/test/cassandra/unit/lib/JSONSchema.js
+++ b/test/cassandra/unit/lib/JSONSchema.js
@@ -82,44 +82,44 @@ describe('JSON Schema', () => {
         assert.equal(jsonSchema.filterData(null), null);
     });
 
-    it('Should return filtered object consisted of primary and clustered keys only', () => {
+    it('Should return filtered object consisted of primary and clustering keys only', () => {
         const schema = new JSONSchema({
             id: 'int',
-            clustered: 'int',
+            clustering: 'int',
             col1: 'text',
 
             __primaryKey__: [ 'id' ],
-            __clusteredKey__: [ 'clustered' ]
+            __clusteringKey__: [ 'clustering' ]
         });
         const data = {
             id: 123,
             col1: 'test',
-            clustered: 111
+            clustering: 111
         };
 
         const keyValues = schema.extractKeys(data);
 
         assert.deepEqual(keyValues, {
             id: 123,
-            clustered: 111
+            clustering: 111
         });
     });
 
     it('Should return filtered object consisted of not key columns only', () => {
         const schema = new JSONSchema({
             id: 'int',
-            clustered: 'int',
+            clustering: 'int',
             col1: 'text',
             col2: 'text',
 
             __primaryKey__: [ 'id' ],
-            __clusteredKey__: [ 'clustered' ]
+            __clusteringKey__: [ 'clustering' ]
         });
         const data = {
             id: 123,
             col1: 'test',
             col2: 'test2',
-            clustered: 111
+            clustering: 111
         };
 
         const notKeyValues = schema.extractNotKeys(data);

--- a/test/cassandra/unit/lib/JSONSchema.js
+++ b/test/cassandra/unit/lib/JSONSchema.js
@@ -177,6 +177,36 @@ describe('JSON Schema', () => {
         assert.equal(schema.comparePrimaryKeyWithMetadata(metadata), false);
     });
 
+    it('Should return true if schema clustering key is same as clustering key in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            col3: 'int',
+            __primaryKey__: [ 'col1' ],
+            __clusteringKey__: [ 'col2', 'col3' ]
+        });
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1');
+        metadataBuilder.withIntColumn('col2').withPrimaryKey('col1').withClusteringKey('col2', 'col3');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.compareClusteringKeyWithMetadata(metadata), true);
+    });
+
+    it('Should return false if schema clustering key is NOT same as clustering key in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            col3: 'int',
+            __primaryKey__: [ 'col2' ],
+            __clusteringKey__: [ 'col1' ]
+        });
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1');
+        metadataBuilder.withIntColumn('col2').withPrimaryKey('col2').withClusteringKey('col2', 'col3');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.compareClusteringKeyWithMetadata(metadata), false);
+    });
+
     it('Should return array of mismatches in case some column types of schema do not match columns in metadata', () => {
         const schema = new JSONSchema({
             id: 'int',

--- a/test/cassandra/unit/lib/JSONSchema.js
+++ b/test/cassandra/unit/lib/JSONSchema.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const MetadataBuilder = require('../../dataBuilders/TableMetadataBuilder');
+const TableMetadataBuilder = require('../../dataBuilders/TableMetadataBuilder');
 
 const JSONSchema = require('../../../../cassandra/lib/JSONSchema');
 
@@ -130,12 +130,12 @@ describe('JSON Schema', () => {
         });
     });
 
-    it('Should return true if schema columns set is same as columns in given metadata object', () => {
+    it('Should return true if schema columns set is same as columns set in given metadata object', () => {
         const schema = new JSONSchema({
             id: 'int',
             __primaryKey__: [ 'id' ]
         });
-        const metadata = new MetadataBuilder().withColumn('id').build();
+        const metadata = new TableMetadataBuilder().withColumn('id').build();
 
         assert.equal(schema.comparePropertySetWithMetadata(metadata), true);
     });
@@ -145,9 +145,36 @@ describe('JSON Schema', () => {
             id: 'int',
             __primaryKey__: [ 'id' ]
         });
-        const metadata = new MetadataBuilder().withColumn('col1').build();
+        const metadata = new TableMetadataBuilder().withColumn('col1').build();
 
         assert.equal(schema.comparePropertySetWithMetadata(metadata), false);
+    });
+
+    it('Should return true if schema primary key is same as primary key in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            __primaryKey__: [ 'col1', 'col2' ]
+        });
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1');
+        metadataBuilder.withIntColumn('col2').withPrimaryKey('col1', 'col2');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.comparePrimaryKeyWithMetadata(metadata), true);
+    });
+
+    it('Should return false if schema primary key is NOT same as primary key in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            col3: 'int',
+            __primaryKey__: [ 'col1', 'col3' ]
+        });
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1');
+        metadataBuilder.withIntColumn('col2').withPrimaryKey('col1', 'col2');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.comparePrimaryKeyWithMetadata(metadata), false);
     });
 
     it('Should return array of mismatches in case some column types of schema do not match columns in metadata', () => {
@@ -156,7 +183,7 @@ describe('JSON Schema', () => {
             Col1: 'text',
             __primaryKey__: [ 'id' ]
         });
-        const metadata = new MetadataBuilder().withTextColumn('id').withIntColumn('col1').build();
+        const metadata = new TableMetadataBuilder().withTextColumn('id').withIntColumn('col1').build();
 
         const mismatches = schema.diffPropertyTypesWithMetadata(metadata);
 
@@ -181,7 +208,7 @@ describe('JSON Schema', () => {
             col1: 'map<text,text>',
             __primaryKey__: [ 'id' ]
         });
-        const mdBuilder = new MetadataBuilder().withIntColumn('id').withMapColumn('col1');
+        const mdBuilder = new TableMetadataBuilder().withIntColumn('id').withMapColumn('col1');
         mdBuilder.withColumnNestedTextType('col1').withColumnNestedTextType('col1');
         const metadata = mdBuilder.build();
 
@@ -197,7 +224,7 @@ describe('JSON Schema', () => {
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
+        const mdBuilder = new TableMetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'my_type');
         const metadata = mdBuilder.build();
 
@@ -213,7 +240,7 @@ describe('JSON Schema', () => {
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
+        const mdBuilder = new TableMetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'my_type').withColumnTypeOption('col1', 'frozen', true);
         const metadata = mdBuilder.build();
 
@@ -229,7 +256,7 @@ describe('JSON Schema', () => {
             __primaryKey__: [ 'id' ]
         });
 
-        const mdBuilder = new MetadataBuilder().withIntColumn('id').withUDTColumn('col1');
+        const mdBuilder = new TableMetadataBuilder().withIntColumn('id').withUDTColumn('col1');
         mdBuilder.withColumnTypeName('col1', 'another_type');
         const metadata = mdBuilder.build();
 
@@ -243,7 +270,7 @@ describe('JSON Schema', () => {
             field1: 'varchar'
         });
 
-        const mdBuilder = new MetadataBuilder().withTextColumn('field1');
+        const mdBuilder = new TableMetadataBuilder().withTextColumn('field1');
         const metadata = mdBuilder.build();
 
         const mismatches = schema.diffPropertyTypesWithMetadata(metadata);

--- a/test/cassandra/unit/lib/QueryBuilder.js
+++ b/test/cassandra/unit/lib/QueryBuilder.js
@@ -8,7 +8,7 @@ describe('Query Builder', () => {
             col1: 'int',
             col2: 'int',
             __primaryKey__: [ 'col1' ],
-            __clusteredKey__: [ 'col2' ]
+            __clusteringKey__: [ 'col2' ]
         };
         const data = {
             col1: 1,
@@ -85,23 +85,23 @@ describe('Query Builder', () => {
             col2: 'int',
             id: 'int',
             id2: 'int',
-            clustered: 'int',
+            clustering: 'int',
             __primaryKey__: [ 'id', 'id2' ],
-            __clusteredKey__: [ 'clustered' ]
+            __clusteringKey__: [ 'clustering' ]
         };
         const data = {
             col1: 'test',
             col2: 111,
             id: 1,
             id2: 2,
-            clustered: 3
+            clustering: 3
         };
 
         const builder = new QueryBuilder().update('table').withJSONSchema(schema).queryParams(data);
 
         const cql = builder.build();
 
-        assert.equal(cql.query, 'UPDATE table SET col1 = ?, col2 = ? WHERE id = ? AND id2 = ? AND clustered = ? IF EXISTS')
+        assert.equal(cql.query, 'UPDATE table SET col1 = ?, col2 = ? WHERE id = ? AND id2 = ? AND clustering = ? IF EXISTS')
         assert.deepEqual(cql.params, [ 'test', 111, 1, 2, 3 ]);
     });
 });

--- a/test/cassandra/unit/lib/TableSchemaBuilder.js
+++ b/test/cassandra/unit/lib/TableSchemaBuilder.js
@@ -10,7 +10,7 @@ describe('Table Schema Builder', () => {
             bigIntField: 'bigint',
             floatField: 'float',
             __primaryKey__: [ 'textField', 'bigIntField' ],
-            __clusteredKey__: [ 'floatField' ]
+            __clusteringKey__: [ 'floatField' ]
         };
         const builder = new TableSchemaBuilder();
 
@@ -20,7 +20,7 @@ describe('Table Schema Builder', () => {
         assert.equal(query, 'CREATE TABLE my_table(textField text,bigIntField bigint,floatField float,PRIMARY KEY((textField,bigIntField),floatField))');
     });
 
-    it('Should build query without clustered key if it does not specified', () => {
+    it('Should build query without clustering key if it does not specified', () => {
         const tableSchema = {
             textField: 'text',
             bigIntField: 'bigint',
@@ -34,12 +34,12 @@ describe('Table Schema Builder', () => {
         assert.equal(query, 'CREATE TABLE my_table(textField text,bigIntField bigint,PRIMARY KEY((bigIntField)))');
     });
 
-    it('Should build query without clustered key if it is zero-length property', () => {
+    it('Should build query without clustering key if it is zero-length property', () => {
         const tableSchema = {
             textField: 'text',
             bigIntField: 'bigint',
             __primaryKey__: [ 'bigIntField' ],
-            __clusteredKey__: []
+            __clusteringKey__: []
         };
 
         const builder = new TableSchemaBuilder();
@@ -67,7 +67,7 @@ describe('Table Schema Builder', () => {
             col2: 'int',
             col3: 'int',
             __primaryKey__: [ 'col1' ],
-            __clusteredKey__: [ 'col2', 'col3' ],
+            __clusteringKey__: [ 'col2', 'col3' ],
             __order__: {
                 col2: 'ASC',
                 col3: 'DESC'
@@ -110,7 +110,7 @@ describe('Table Schema Builder', () => {
             col1: 'int',
             col2: 'int',
             __primaryKey__: [ 'col1' ],
-            __clusteredKey__: [ 'col2' ],
+            __clusteringKey__: [ 'col2' ],
             __options__: {
                 bloom_filter_fp_chance: 0.1
             },

--- a/test/cassandra/unit/src/CassandraStorage.js
+++ b/test/cassandra/unit/src/CassandraStorage.js
@@ -115,7 +115,7 @@ describe('Cassandra Storage Provider', () => {
             command: 'text',
             timestamp: 'timestamp',
             __primaryKey__: [ 'command' ],
-            __clusteredKey__: [ 'timestamp' ]
+            __clusteringKey__: [ 'timestamp' ]
         }).build();
         const batchSpy = MockCassandraClient.prototype.batch;
 
@@ -151,7 +151,7 @@ describe('Cassandra Storage Provider', () => {
             timestamp: 'timestamp',
             someNonexistentField: 'int',
             __primaryKey__: [ 'command' ],
-            __clusteredKey__: [ 'timestamp' ]
+            __clusteringKey__: [ 'timestamp' ]
         }).build();
         const batchSpy = MockCassandraClient.prototype.batch;
 

--- a/test/cassandra/unit/src/CassandraStorage.js
+++ b/test/cassandra/unit/src/CassandraStorage.js
@@ -380,6 +380,39 @@ describe('Cassandra Storage Provider', () => {
         });
     });
 
+    it('Should emit "clusteringKeyMismatch" event if schema has clustering key different from real one', done => {
+        const metadataBuilder = new TableMetadataBuilder().withName('testTable').withIntColumn('col1');
+        metadataBuilder.withIntColumn('col2').withIntColumn('col3').withPrimaryKey('col1').withClusteringKey('col3');
+
+        const metadata = metadataBuilder.build();
+        MockCassandraClient.prototype.metadata.getTable.returns(Promise.resolve(metadata));
+        const cassandra = new CassandraStorage(new MockCassandraClient());
+        const schemas = {
+            testTable: {
+                col1: 'int',
+                col2: 'int',
+                col3: 'int',
+                __primaryKey__: [ 'col1' ],
+                __clusteringKey__: [ 'col2' ]
+            }
+        };
+
+        cassandra.setTableSchemas(schemas);
+        const notifier = cassandra.compareTableSchemas();
+
+        sinon.spy(notifier, 'emit');
+
+        asyncAssertion(() => {
+            assert.equal(notifier.emit.callCount, 3, 'Number of times event was emitted');
+
+            const [ event, tableName ] = notifier.emit.secondCall.args;
+            assert.equal(event, 'clusteringKeyMismatch');
+            assert.equal(tableName, 'testTable');
+
+            done();
+        });
+    });
+
     it('Should emit "customTypeExists" event if user defined type already exists', done => {
         const metadata = new UDTMetadataBuilder().withName('test_udt').withIntField('test_field').build();
         MockCassandraClient.prototype.metadata.getUdt.returns(Promise.resolve(metadata));


### PR DESCRIPTION
- Fail schema creation and plugin app in case clustering and/or primary key mismatch in schema and in existing table
- Fix typo in "clustering" word