### PR TITLE
DEV-388:ADD: Compare clustering order before application start up

### DIFF
--- a/cassandra/lib/JSONSchema.js
+++ b/cassandra/lib/JSONSchema.js
@@ -237,6 +237,15 @@ class JSONSchema {
     }
 
     /**
+     * Returns true if schema contains same ordering as metadata
+     * @param metadataDescriptor
+     * @returns {boolean|*}
+     */
+    compareOrderingWithMetadata(metadataDescriptor) {
+        return Metadata.create(metadataDescriptor).isSameOrdering(this);
+    }
+
+    /**
      * Returns array of property types mismatches in schema with metadata
      * @param metadataDescriptor cassandra-driver metadata object
      * @returns {Array}
@@ -295,6 +304,10 @@ class JSONSchema {
      */
     getClusteringKey() {
         return JSONSchema.validClusteringKey(this._schema) ? [].concat(this._schema[JSONSchema.CLUSTERING_KEY]) : [];
+    }
+
+    getOrder() {
+        return Utils.copy(this._schema[JSONSchema.ORDER]);
     }
 
     /**

--- a/cassandra/lib/metadata/Metadata.js
+++ b/cassandra/lib/metadata/Metadata.js
@@ -58,6 +58,15 @@ class Metadata {
     }
 
     /**
+     * Returns true if schema has same ordering as metadata
+     * @param jsonSchema
+     * @returns {boolean}
+     */
+    isSameOrdering(jsonSchema) {
+        return true;
+    }
+
+    /**
      * Returns true if JSON schema is the same as metadata of real schema (contains same members)
      * @param {JSONSchema} jsonSchema
      * @param {Array<string>} metadataProps Array of member names of structure (table or UDT)

--- a/cassandra/lib/metadata/TableMetadata.js
+++ b/cassandra/lib/metadata/TableMetadata.js
@@ -44,6 +44,29 @@ class TableMetadata extends Metadata {
 
         return jsonSchemaKey.every(k => metadataKey.includes(k));
     }
+
+    isSameOrdering(jsonSchema) {
+        if (!this.isSameClusteringKey(jsonSchema)) {
+            return false;
+        }
+
+        const mdClusteringKeys = this._md.clusteringKeys;
+        const mdOrder = this._md.clusteringOrder;
+        const schemaOrder = jsonSchema.getOrder();
+
+        let valid = true;
+        for (let i = 0; i < mdClusteringKeys.length; i++) {
+            const ck = mdClusteringKeys[i];
+            const schemaCKOrder = schemaOrder[ck.name] || 'ASC';
+
+            valid = schemaCKOrder.toUpperCase().trim() === mdOrder[i].toUpperCase();
+            if (!valid) {
+                break;
+            }
+        }
+
+        return valid;
+    }
 }
 
 module.exports = TableMetadata;

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -277,9 +277,7 @@ class CassandraStorage {
 
                 if (!schema.compareClusteringKeyWithMetadata(md)) {
                     notifier.notifyClusteringKeyMismatch(name);
-                }
-
-                if (!schema.compareOrderingWithMetadata(md)) {
+                } else if (!schema.compareOrderingWithMetadata(md)) {
                     notifier.notifyClusteringOrderMismatch(name);
                 }
             });

--- a/cassandra/src/CassandraStorage.js
+++ b/cassandra/src/CassandraStorage.js
@@ -278,6 +278,10 @@ class CassandraStorage {
                 if (!schema.compareClusteringKeyWithMetadata(md)) {
                     notifier.notifyClusteringKeyMismatch(name);
                 }
+
+                if (!schema.compareOrderingWithMetadata(md)) {
+                    notifier.notifyClusteringOrderMismatch(name);
+                }
             });
         });
 

--- a/cassandra/src/SchemaComparisonNotifier.js
+++ b/cassandra/src/SchemaComparisonNotifier.js
@@ -6,6 +6,7 @@ class SchemaComparisonNotifier extends EventEmitter {
         this._notificationEvents = { ...events };
         this._notificationEvents.primaryKeyMismatch = 'primaryKeyMismatch';
         this._notificationEvents.clusteringKeyMismatch = 'clusteringKeyMismatch';
+        this._notificationEvents.clusteringOrderMismatch = 'clusteringOrderMismatch';
     }
 
     notifyExistence(name) {
@@ -26,6 +27,10 @@ class SchemaComparisonNotifier extends EventEmitter {
 
     notifyClusteringKeyMismatch(name) {
         return this.emit(this._notificationEvents.clusteringKeyMismatch, name);
+    }
+
+    notifyClusteringOrderMismatch(name) {
+        return this.emit(this._notificationEvents.clusteringOrderMismatch, name);
     }
 }
 

--- a/plugin/cassandraInit.js
+++ b/plugin/cassandraInit.js
@@ -73,6 +73,9 @@ function schemaComparison(cassandra) {
         }).on('clusteringKeyMismatch', tableName => {
             console.log(`TABLE ${tableName}: Mismatched clustering key`);
             ok = false;
+        }).on('clusteringOrderMismatch', tableName => {
+            console.log(`TABLE ${tableName}: Mismatched clustering order`);
+            ok = false;
         }).on('done', () => {
             if (ok) {
                 resolve();

--- a/plugin/cassandraSchema/SchemaCreator.js
+++ b/plugin/cassandraSchema/SchemaCreator.js
@@ -36,6 +36,9 @@ class SchemaCreator {
             }).on('clusteringKeyMismatch', tableName => {
                 console.log(`TABLE ${tableName}: Mismatched clustering key`);
                 ok = false;
+            }).on('clusteringOrderMismatch', tableName => {
+                console.log(`TABLE ${tableName}: Mismatched clustering order`);
+                ok = false;
             }).on('done', () => {
                 if (ok) {
                     resolve();

--- a/test/cassandra/dataBuilders/TableMetadataBuilder.js
+++ b/test/cassandra/dataBuilders/TableMetadataBuilder.js
@@ -1,6 +1,10 @@
 const DataBuilder = require('smp-data-builder');
 
 class TableMetadataBuilder extends DataBuilder {
+    withOrdering(order) {
+        return this.with('clusteringOrder', [ order ]);
+    }
+
     withClusteringKey(...colNames) {
         return this.withKey('clustering', ...colNames);
 

--- a/test/cassandra/unit/lib/JSONSchema.js
+++ b/test/cassandra/unit/lib/JSONSchema.js
@@ -207,6 +207,46 @@ describe('JSON Schema', () => {
         assert.equal(schema.compareClusteringKeyWithMetadata(metadata), false);
     });
 
+    it('Should return true if schema table ordering is same as ordering in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            col3: 'int',
+            __primaryKey__: [ 'col1' ],
+            __clusteringKey__: [ 'col2', 'col3' ],
+            __order__: {
+                col3: 'DESC'
+            }
+        });
+
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1').withIntColumn('col2');
+        metadataBuilder.withPrimaryKey('col1').withClusteringKey('col2').withOrdering('ASC');
+        metadataBuilder.withClusteringKey('col3').withOrdering('DESC');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.compareOrderingWithMetadata(metadata), true);
+    });
+
+    it('Should return false if schema table ordering is NOT same as ordering in given metadata object', () => {
+        const schema = new JSONSchema({
+            col1: 'int',
+            col2: 'int',
+            col3: 'int',
+            __primaryKey__: [ 'col1' ],
+            __clusteringKey__: [ 'col2', 'col3' ],
+            __order__: {
+                col2: 'DESC'
+            }
+        });
+
+        const metadataBuilder = new TableMetadataBuilder().withIntColumn('col1').withIntColumn('col2');
+        metadataBuilder.withPrimaryKey('col1').withClusteringKey('col2').withOrdering('ASC');
+        metadataBuilder.withClusteringKey('col3').withOrdering('ASC');
+        const metadata = metadataBuilder.build();
+
+        assert.equal(schema.compareOrderingWithMetadata(metadata), false);
+    });
+
     it('Should return array of mismatches in case some column types of schema do not match columns in metadata', () => {
         const schema = new JSONSchema({
             id: 'int',


### PR DESCRIPTION
Fail plugin and schema creation services if clustering order of existing table doesn't match with ordering defined in schema